### PR TITLE
Add gitignore with Vagrant files, /old, and .DS_Store ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/old
+Vagrantfile
+/.vagrant
+.DS_Store


### PR DESCRIPTION
Adding a .gitignore.

What this means for other folks is if you want to have some local files in your dir but keep them out of source code, put them in `/old` and they'll be ignored.

Also ignoring my Vagrant-related files for now, but may check in eventually. (Vagrant rules.)
