### PR TITLE
76 whitespace and more

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -1,11 +1,55 @@
 /* Overriding Bootstrap style for more screen margins on mobile */
-#main {
-	max-width: 700px;
+
+.masthead-page {
+	display: inline-block;
+	width: auto;
+	height: auto;
+	padding: 2em 0;
+	background-color: #00618D;
+	/* alternates */
+	/* darker #00618D*/
+	/* mid #BAD2DF*/
+	/* light #DFE9EE */
 }
 
-.subhead {
-	line-height: 1.6;
+.masthead-page .lead {
+	color: #f1f1f1;
 }
 
+.form-body {
+	display: inline-block;
+	width: 100%;
+	padding: 2em 0;
+}
 
+.form-page {
+	display: inline-block;
+	width: 100%;
+}
+
+.page-content {}
+
+.form-section {
+	padding: 1em 0;
+}
+
+.section-intro {
+	padding: .5em 0;
+}
+
+.section-lead {
+	font-weight: 200;
+	line-height: 1.4;
+	font-size: ;
+}
+
+.form-group {}
+
+.file-group {
+	padding: .5em 0;
+}
+
+h1 {
+	color: #f1f1f1;
+}
 

--- a/views/index.erb
+++ b/views/index.erb
@@ -1,148 +1,151 @@
-<form role="form" name="apply" action="applications" method="post" enctype="multipart/form-data">
-  <div class="row">
-    <div class="col-md-12">
-      <h1>Apply for CalFresh in San Francisco</h1>
-      <br>
-      <p class="lead">With some basic personal information, a few photos of important documents, and your signature, you can apply for food benefits. If you are eligible for Calfresh, you are likely eligible for the Medi-cal health insurance program as well.</p>
-      <hr>
-    </div>
+<div class="masthead-page">
+  <div class="col-md-8 col-md-offset-2 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
+    <h1>Apply for CalFresh in San Francisco</h1>
+    <br>
+    <p class="lead">With some basic personal information, a few photos of important documents, and your signature, you can apply for food benefits. If you are eligible for Calfresh, you are likely eligible for the Medi-cal health insurance program as well.</p>
   </div>
-  <div class="row">
-    <div class="col-md-12">
-      <h2 class="h4">Your Basic Information</h2>
-      <div class="bs-callout bs-callout-info">
-        <span class="help-block">Type your full legal name--it's required to receive benefits from CalFresh.</span>
+</div>
+<div class="form-body">
+  <form role="form" name="apply" action="applications" method="post" enctype="multipart/form-data">
+    <section class="form-page personal-info-page">
+      <div class="page-content col-md-8 col-md-offset-2 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
+        <section class="form-section">
+          <div class="section-intro">
+            <h2 class="h3">Your Basic Information</h2>
+            <p class="lead">Type your full legal name--it's required to receive benefits from CalFresh.</p>
+          </div>
+          <div class="form-group">
+              <label for="name">Name</label>
+              <input type="text" class="form-control" name="name" id="name" placeholder="ex. Joanna Smith">
+          </div>
+          <div class="form-group">
+            <label for="sex">Sex</label>
+            <select class="form-control" id="sex" name="sex">
+              <option>Female</option>
+              <option>Male</option>
+              <option>Prefer not to answer</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label for="date_of_birth">Date of Birth</label>
+              <input type="text" class="form-control" name="date_of_birth" id="date_of_birth" placeholder="ex. 1/14/82">
+          </div>
+          <div class="form-group">
+            <label for="ssn">Social Security Number</label>
+              <input type="text" class="form-control" name="ssn" id="ssn" placeholder="ex. 000112222">
+          </div>
+        </section>
+        <section class="form-section">
+          <div class="section-intro">
+            <h2 class="h3">Your Best Address</h2>
+            <p class="lead">You <b>must</b> live in San Francisco to use this application. Provide your City of San Francisco mailing address so CalFresh can send along important information about your application.</p>
+          </div>
+          <div class="form-group">
+            <label for="home_address">Street Address</label>
+              <input type="text" class="form-control" name="home_address" placeholder="ex. 1200 Market St">
+          </div>
+          <div class="form-group">
+            <label for="home_zip_code">ZIP Code</label>
+              <input type="text" class="form-control" name="home_zip_code" placeholder="ex. 94117">
+          </div>
+          <input type="hidden" class="form-control" name="home_city" value="San Francisco">
+          <input type="hidden" class="form-control" name="home_state" value="CA">
+        </section>
+        <section class="form-section">
+          <div class="section-intro">
+            <h2 class="h3">Your Contact Information</h2>
+            <p class="lead">You don't have to include your phone number or email address, but it will help CalFresh staff get in touch with you.</p>
+          </div>
+          <div class="form-group">
+            <label for="home_phone_number">Phone number</label>
+            <input type="text" class="form-control" name="home_phone_number" placeholder="ex. (415) 555-5555">
+          </div>
+          <div class="form-group">
+            <label for="email">Email</label>
+            <input type="text" class="form-control" name="email" placeholder="ex. joanna.smith@gmail.com">
+          </div>
+          <div class="form-group">
+            <label for="primary_language">Language Preference</label>
+            <select class="form-control" name="primary_language">
+              <% @language_options.each do |language| %>
+                <option value="<%= language %>"><%= language %></option>
+              <% end %>
+            </select>
+          </div>
+        </section>
       </div>
-      <div class="form-group">
-          <label for="name">Name</label>
-          <input type="text" class="form-control" name="name" id="name" placeholder="ex. Joanna Smith">
+    </section>
+    <section class="form-page verification-document-page">
+      <div class="page-content col-md-8 col-md-offset-2 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
+        <section class="form-section">
+          <div class="section-intro">
+              <h2 class="h3">Please Upload Photos of Key Documents and Information</h2>
+              <p class="lead">In order to enroll in CalFresh, the staff will need to confirm that you are eligible. Aside from residency in San Francisco, eligibility is mostly a matter of your income and expenses.</p>
+            </div>
+            <div class="form-group file-group">
+              <label for="identification">Your Photo ID</label>
+              <input type="file" name="identification">
+              <p class="help-block">Upload a photo of your Driver's License, Passport or other government-issued photo ID.</p>
+            </div>
+            <div class="form-group file-group">
+              <label for="income">Your Income</label>
+              <input type="file" name="income">
+              <p class="help-block">Upload a photo documenting your income or wages. This could be a photo of a paystub, bank statement. If you don't have any of those, simply write down your weekly or monthly income on a piece of paper, then upload a photo of that note.</p>
+            </div>
+            <div class="form-group file-group">
+              <label for="rent">Your Expenses: Rent</label>
+              <input type="file" name="rent">
+              <p class="help-block">Upload a photo documenting your monthly rent expenses. This could be a photo of a lease agreement or a rent check. If you don't have any of those, simply write down your monthly rent on a piece of paper, then upload a photo of that note.</p>
+            </div>
+            <div class="form-group file-group">
+              <label for="utilities">Your Expenses: Utilities</label>
+              <input type="file" name="utilities">
+              <p class="help-block">Upload a photo documenting your monthly utility expenses. Utilities include electricity, gas, water and garbage collection. This could be a photo of your monthly statements, bills, or checks you've written. If you don't have any of those, simply write down your monthly utility expenses on a piece of paper, then upload a photo of that note.</p>
+            </div>
+        </section>
       </div>
-      <div class="form-group">
-        <label for="sex">Sex</label>
-        <select class="form-control" id="sex" name="sex">
-          <option>Female</option>
-          <option>Male</option>
-          <option>Prefer not to answer</option>
-        </select>
-      </div>
-      <div class="form-group">
-        <label for="date_of_birth">Date of Birth</label>
-          <input type="text" class="form-control" name="date_of_birth" id="date_of_birth" placeholder="ex. 1/14/82">
-      </div>
-      <div class="form-group">
-        <label for="ssn">Social Security Number</label>
-          <input type="text" class="form-control" name="ssn" id="ssn" placeholder="ex. 000112222">
-      </div>
-    </div>
-    <hr>  <!-- keyline -->
-  </div>
-  <div class="row">
-    <div class="col-md-12">
-      <h2 class="h4">Your Best Address</h2>
-      <div class="form-group">
-        <span class="help-block">You <b>must</b> live in San Francisco to use this application. Provide your City of San Francisco mailing address so CalFresh can send along important information about your application.</span>
-        <label for="home_address">Street Address</label>
-          <input type="text" class="form-control" name="home_address" placeholder="ex. 1200 Market St">
-      </div>
-      <div class="form-group">
-        <label for="home_zip_code">ZIP Code</label>
-          <input type="text" class="form-control" name="home_zip_code" placeholder="ex. 94117">
-      </div>
-      <input type="hidden" class="form-control" name="home_city" value="San Francisco">
-      <input type="hidden" class="form-control" name="home_state" value="CA">
-    </div>
-    <hr>  <!-- keyline -->
-  </div>
-  <div class="row">
-    <div class="col-md-12">
-      <h2 class="h4">Your Contact Information</h2>
-      <span class="help-block">You don't have to include your phone number or email address, but it will help CalFresh staff get in touch with you.</span>
-      <div class="form-group">
-        <label for="home_phone_number">Phone number</label>
-          <input type="text" class="form-control" name="home_phone_number" placeholder="ex. (415) 555-5555">
-      </div>
-      <div class="form-group">
-        <label for="email">Email</label>
-          <input type="text" class="form-control" name="email" placeholder="ex. joanna.smith@gmail.com">
-      </div>
-      <div class="form-group">
-        <label for="primary_language">Language Preference</label>
-          <select class="form-control" name="primary_language">
-            <% @language_options.each do |language| %>
-              <option value="<%= language %>"><%= language %></option>
-            <% end %>
-          </select>
-      </div>
-    </div>
-    <hr>  <!-- keyline -->
-  </div>
-  <div class="row">
-    <div class="col-md-12">
-      <h2 class="h4">Please Upload Photos of Key Documents and Information</h2>
-        <p class="help-block">In order to enroll in CalFresh, the staff will need to confirm that you are eligible. Aside from residency in San Francisco, eligibility is mostly a matter of your income and expenses.</p>
-      <div class="form-group">
-        <label for="identification">Your Photo ID</label>
-        <input type="file" name="identification">
-        <p class="help-block">Upload a photo of your Driver's License, Passport or other government-issued photo ID.</p>
-      </div>
-      <div class="form-group">
-        <label for="income">Your Income</label>
-        <input type="file" name="income">
-        <p class="help-block">Upload a photo documenting your income or wages. This could be a photo of a paystub, bank statement. If you don't have any of those, simply write down your weekly or monthly income on a piece of paper, then upload a photo of that note.</p>
-      </div>
-      <div class="form-group">
-        <label for="rent">Your Expenses: Rent</label>
-        <input type="file" name="rent">
-        <p class="help-block">Upload a photo documenting your monthly rent expenses. This could be a photo of a lease agreement or a rent check. If you don't have any of those, simply write down your monthly rent on a piece of paper, then upload a photo of that note.</p>
-      </div>
-      <div class="form-group">
-        <label for="utilities">Your Expenses: Utilities</label>
-        <input type="file" name="utilities">
-        <p class="help-block">Upload a photo documenting your monthly utility expenses. Utilities include electricity, gas, water and garbage collection. This could be a photo of your monthly statements, bills, or checks you've written. If you don't have any of those, simply write down your monthly utility expenses on a piece of paper, then upload a photo of that note.</p>
-      </div>
-    </div>
-    <hr> <!-- keyline -->
-  </div>
-  <div class="row">
-    <div class="col-md-12">
-      <h2 class="h4">Your Signature</h2>
-      <div class="form-group">
-        <p>I understand that by signing this application under penalty of perjury (making false statements), that:</p>
-        <ul>
-          <li>I read, or had read to me, the information in this application and my answers to the questions in this application.</li>
-          <li>My answers to the questions are true and complete to the best of my knowledge.</li>
-          <li>Any answers I may give for my application process will be true and complete to the best of my knowledge.</li>
-          <li>I read or had read to me and I understand and agree to the Rights and Responsibilities (Program Rules Page 1) for the CalFresh Program.</li>
-          <li>I read, or had read to me, the CalFresh Program Rules and Penalties (Program Rules Pages 2 through 3).</li>
-          <li>I understand that giving false or misleading statements or misrepresenting, hiding or withholding facts to establish eligibility for CalFresh is fraud. Fraud can cause a criminal case to be filed against me and/or I may be barred for a period of time (or life) from getting CalFresh benefits.
-          <li>I understand that Social Security Numbers or immigration status for household members applying for benefits may be shared with the appropriate government agencies as required by federal law.</li>
-        </ul>
-      </div>
-      <br>
-      <span class="help-block">Sign on the line. You can sign with your mouse or your finger if you're using a touch screen.</span>
-      <div id="signature_area" class="panel"></div>
-      <div id="signature_value_hidden"></div>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-md-12">
-      <div class="form-group">
-        <h2 class="h4">Confirm and Submit</h2>
+    </section>
+    <section class="form-page confirmation-page">
+      <div class="page-content col-md-8 col-md-offset-2 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
+        <section class="form-section">
+            <h2 class="h3">Your Signature</h2>
+            <div class="form-group">
+              <p>I understand that by signing this application under penalty of perjury (making false statements), that:</p>
+              <ul>
+                <li>I read, or had read to me, the information in this application and my answers to the questions in this application.</li>
+                <li>My answers to the questions are true and complete to the best of my knowledge.</li>
+                <li>Any answers I may give for my application process will be true and complete to the best of my knowledge.</li>
+                <li>I read or had read to me and I understand and agree to the Rights and Responsibilities (Program Rules Page 1) for the CalFresh Program.</li>
+                <li>I read, or had read to me, the CalFresh Program Rules and Penalties (Program Rules Pages 2 through 3).</li>
+                <li>I understand that giving false or misleading statements or misrepresenting, hiding or withholding facts to establish eligibility for CalFresh is fraud. Fraud can cause a criminal case to be filed against me and/or I may be barred for a period of time (or life) from getting CalFresh benefits.
+                <li>I understand that Social Security Numbers or immigration status for household members applying for benefits may be shared with the appropriate government agencies as required by federal law.</li>
+              </ul>
+            </div>
+            <br>
+            <span class="help-block">Sign on the line. You can sign with your mouse or your finger if you're using a touch screen.</span>
+            <div id="signature_area" class="panel"></div>
+            <div id="signature_value_hidden"></div>
+        </section>
+        <section class="form-section">
+            <div class="form-group">
+              <h2 class="h3">Confirm and Submit</h2>
 
-        <div class="checkbox">
-          <label>
-            <input type="checkbox" name="medi_cal_interest"> Are you interested in applying for Medi-Cal?
-          </label>
-        </div>
-        <div class="checkbox">
-          <label>
-            <input type="checkbox"> By clicking this box, you confirm your intent to submit this application to receive benefits from CalFresh. This web tool will take the information you have provided, and transcribe it onto an official CalFresh application form. That form, along with any documents you upload, will then automatically be faxed to the City of San Francisco Health Services Administration.
-          </label>
-        </div>
+              <div class="checkbox">
+                <label>
+                  <input type="checkbox" name="medi_cal_interest"> Are you interested in applying for Medi-Cal?
+                </label>
+              </div>
+              <div class="checkbox">
+                <label>
+                  <input type="checkbox"> By clicking this box, you confirm your intent to submit this application to receive benefits from CalFresh. This web tool will take the information you have provided, and transcribe it onto an official CalFresh application form. That form, along with any documents you upload, will then automatically be faxed to the City of San Francisco Health Services Administration.
+                </label>
+              </div>
+            </div>
+            <div class="form-group">
+              <button type="submit" id="submit_button" class="btn btn-default">Submit your CalFresh application!</button>
+            </div>
+        </section>
       </div>
-      <div class="form-group">
-        <button type="submit" id="submit_button" class="btn btn-default">Submit your CalFresh application!</button>
-      </div>
-    </div>
-  </div>
-</form>
+    </section>
+  </form>
+</div>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -36,7 +36,7 @@
 
 
   <body>
-    <div class="container-fluid" id="main">
+    <div id="main">
       <%= yield %>
     </div>
   </body>


### PR DESCRIPTION
- This PR resolves #76 
- This PR should conform to our prescribed feature-branch > rebase > PR workflow.
- The primary change here is a restructuring of the markup on index.erb. We now have a more semantic and granular page structure, which moves us in the direction of more flexible and nuanced styling.
- Via the improved markup, we've added quite a bit of additional whitespace between form elements. This will help with scanning the form visually.
- We've upped the typography size in a few places, and refined the typographic hierarchy.
- Perhaps most noticeably, the title and subhead are now visually and structurally discrete from the form itself, evidenced primarily by a full-width blue background and off-white text.
- These styles are not meant to be indicative of a long-term direction, but rather to improve the experience for 7/30/2014.
