### PR TITLE
Submit button disabled, styled gracefully

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -377,40 +377,7 @@ body {
 
 /* F O R M   B U T T O N --- D I S A B L E E D / I N   P R O G R E S S */
 
-input.disabled {
-  color: #333;
-  background-color: #e1e0dc;
-/*  background-color: #f6f5f0;*/
-  border: 1px solid #d3d3d3;
-  cursor: auto;
-  text-shadow: white 0 1px 0;
-  -webkit-box-shadow: white 0 1px 0 0 inset;
-  -moz-box-shadow: white 0 1px 0 0 inset;
-  -ms-box-shadow: white 0 1px 0 0 inset;
-  -o-box-shadow: white 0 1px 0 0 inset;
-  box-shadow: white 0 1px 0 0 inset;
-}
-
-.in-progress {
-  text-shadow: none;
-  background: -webkit-linear-gradient(-45deg, rgba(255, 255, 255, 0.6) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.6) 50%, rgba(255, 255, 255, 0.6) 75%, transparent 75%, transparent);
-  background: -moz-linear-gradient(-45deg, rgba(255, 255, 255, 0.6) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.6) 50%, rgba(255, 255, 255, 0.6) 75%, transparent 75%, transparent);
-  background: -ms-linear-gradient(-45deg, rgba(255, 255, 255, 0.6) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.6) 50%, rgba(255, 255, 255, 0.6) 75%, transparent 75%, transparent);
-  background: -o-linear-gradient(-45deg, rgba(255, 255, 255, 0.6) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.6) 50%, rgba(255, 255, 255, 0.6) 75%, transparent 75%, transparent);
-  background: linear-gradient(-45deg, rgba(255, 255, 255, 0.6) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.6) 50%, rgba(255, 255, 255, 0.6) 75%, transparent 75%, transparent);
-  -pie-background: linear-gradient(-45deg, rgba(255, 255, 255, 0.6) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.6) 50%, rgba(255, 255, 255, 0.6) 75%, transparent 75%, transparent);
-  background-repeat: repeat;
-  -webkit-background-size: 40px 40px, 100% 100%;
-  -moz-background-size: 40px 40px, 100% 100%;
-  -ms-background-size: 40px 40px, 100% 100%;
-  -o-background-size: 40px 40px, 100% 100%;
-  background-size: 40px 40px, 100% 100%;
-  -webkit-animation: progress-bar-stripes 2s linear infinite;
-  -moz-animation: progress-bar-stripes 2s linear infinite;
-  -ms-animation: progress-bar-stripes 2s linear infinite;
-  -o-animation: progress-bar-stripes 2s linear infinite;
-  animation: progress-bar-stripes 2s linear infinite;
-}
+ /* These classes have been removed, but let's keep the keyframes JIC */
 
 @-webkit-keyframes progress-bar-stripes {
   from { background-position: 0 0; }
@@ -427,7 +394,7 @@ input.disabled {
   to { background-position: 40px 0; }
 }
 
-/* F O R M   L I S T S */
+/* F O R M   L I S T S 
 
 /* Sie by side lists, found on the interview.html */
 /* We want two columns, taking up the entire width of

--- a/views/review_and_submit.erb
+++ b/views/review_and_submit.erb
@@ -3,7 +3,7 @@
     <p class="program"> CALFRESH & MEDI-CAL</p>
   </div>
 </div>
-<form name="review_and_submit" action="/application/review_and_submit" method="post" class="form col-lg-4 col-lg-offset-4 col-md-6 col-md-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1" data-parsley-validate>
+<form name="review_and_submit" id="review_and_submit" action="/application/review_and_submit" method="post" class="form col-lg-4 col-lg-offset-4 col-md-6 col-md-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1" data-parsley-validate>
   <h3>Confirm and Submit</h3>
   <div class="form-group">
     <p><b>You'll need to read the following carefully, and then sign your name. It's important that you understand everything you agree to by signing and submitting this application for Calfresh.</b></p>
@@ -35,7 +35,7 @@
   <div class="form-group">
     <div class="checkbox">
       <p>
-        <input type="checkbox" name="confirmation" required data-parsley-required-message="Click the box above to confirm that you have read and are okay with how we are submitting your application (described above)." \><b>Check this box to confirm your intent to submit your CalFresh application.</b>
+        <input type="checkbox" name="confirmation" id="confirmation" required data-parsley-required-message="Click the box above to confirm that you have read and are okay with how we are submitting your application (described above)." \><b>Check this box to confirm your intent to submit your CalFresh application.</b>
             By clicking this box, you confirm your intent to submit this application to receive benefits from CalFresh. This web tool will take the information you have provided, and transcribe it onto an official CalFresh application form. That form, along with any documents you upload, will then automatically be faxed to the City of San Francisco Human Services Administration.
       </p>
       <label></label>
@@ -50,9 +50,17 @@
   $('.btn').button();
   $(function() {
      $("#submit_button").click(function() {
-      if ($( '#formId' ).parsley( 'isValid' )) {
+      if ($( '#review_and_submit' ).parsley().isValid()) {
+        $(this).attr("disabled", "disabled");
+        $(this).css({
+            color: '#333',
+            'background-color': '#e1e0dc',
+            border: '1px solid #d3d3d3',
+            cursor: 'auto'
+        });
         $(this).addClass("disabled in-progress");
         $(this).val('Submitting...')
+        $(this).blur();
       } else {}
      });
   });


### PR DESCRIPTION
This PR:
- Should close #157 
- Removes the css animation we had as a "submitting state" 
- Replaces it with a more basic "disabled style" that still uses copy to inform the user the form is being submitted
- Applies these styles in-line, to route around some difficulty rendering styles as the form was being POSTed.
- Has been tested on iPad/iPhone, Android devices via Chrome's new devtools.
