### PR TITLE
removed raw data link - closes #202

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ heroku config:set LD_LIBRARY_PATH=/app/vendor/pdftk/lib
 ```
 
 ## Metrics on production deployment
-Our primary metrics are ([raw data](https://docs.google.com/a/codeforamerica.org/spreadsheets/d/1Erj1etuAX8ZKhYRwZ9nL9gkRBjf43Hatv7wQNyqljr0/edit#gid=1258013118)):
+Our primary metrics are:
 - # of approved applications (quantity)
 - % of submitted applications approved (quality)
 


### PR DESCRIPTION
Removed the raw data link because we're now collecting a bit more information for each application (case #s) and I'd rather not expose it publicly unless there's a compelling reason.
