### PR TITLE
Add 404 and 500 error pages

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -18,50 +18,100 @@
     margin: 4em auto 0;
   }
 
-  div.dialog > div {
+  div.dialog > .message {
     border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
     background-color: white;
     padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+    text-align: left;
   }
 
   h1 {
-    font-size: 100%;
-    color: #730E15;
+    font-size: 21px;
+    color: #2E394B;;
+    line-height: 1.5em;
+  }
+  h2 {
+    font-size: 18px;
+    color: #2E394B;;
     line-height: 1.5em;
   }
 
-  div.dialog > p {
+  div.dialog > .instructions {
     margin: 0 0 1em;
-    padding: 1em;
+    padding: 7px 12% 0;
     background-color: #F7F7F7;
     border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+    border-top: 0;
+    color: #2E394B;
+
+  }
+
+  body {
+  margin: 0;
+  background:  #fff;
+  width: 100%;
+  height: 100%;
+  }
+
+  #main {
+  background: #fff;
+  position: absolute;
+  bottom: 0;
+  top: 0;
+  left: 0;
+  right: 0;
+  }
+
+  .masthead {
+  display: inline-block;
+  width: 100%;
+  height: auto;
+  padding: .2em 0;
+  /* Blue background color */
+  background-color: #2E394B;
+  }
+  .program {
+    color: #F1AB00;
+    font-size: 16px;
+    font-family: sans-serif;
+    font-weight: 100;
+    letter-spacing: 0.25em;
+    display: inline-block;
+    margin-top: 12px;
+    margin-bottom: 8px;
   }
   </style>
 </head>
 
 <body>
   <!-- This file lives in public/404.html -->
-  <div class="dialog">
-    <div>
-      <h1>The page you were looking for doesn't exist.</h1>
-      <p>You may have mistyped the address or the page may have moved.</p>
+  <div id="main">
+    <div class="masthead">
+      <div>
+        <p class="program">CLEANASSIST.ORG</p>
+      </div>
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
+    <div class="dialog">
+      <div class="message">
+        <h1>Hmmm...the page you were looking for doesn't exist.</h1>
+        <p>You may have mistyped the address, or something may be wrong.</p>
+      </div>
+      <div class="instructions" style="text-align:left">
+        <h3>Still not working? Here's what to do:</h3>
+        <ul>
+          <li>
+            <b>If you have not submitted an application yet:</b>
+            <p>You can always use <a href="https://www.mybenefitscalwin.org/">MyBenefitsCalWIN.</a>It's long, but if you submit an application at 15% complete *and* upload verification documents, your client will have a good shot at enrolling.</p>
+          </li>
+          <li>
+            <b>If you had already submitted an application, but are trying to submit verificaiton documents:</b>
+            <p>Email the documents to <a href="mailto:food@sfgov.org">food@sfgov.org</a>. In the subject line, write "Pending Intake for [Applicant Name]". In the body of the email, describe the attached couments, and state that the application was submitted on today's date and time via "Clean".</p>
+          </li>
+        </ul>
+      </div>
+    </div>
   </div>
 </body>
 </html>

--- a/public/404.html
+++ b/public/404.html
@@ -110,6 +110,7 @@
             <p>Email the documents to <a href="mailto:food@sfgov.org">food@sfgov.org</a>. In the subject line, write "Pending Intake for [Applicant Name]". In the body of the email, describe the attached couments, and state that the application was submitted on today's date and time via "Clean".</p>
           </li>
         </ul>
+        <p>Need help right away? Get in touch with us at <a href="mailto:health-lab@codeforamerica.org">health-lab@codeforamerica.org</a>.</p>
       </div>
     </div>
   </div>

--- a/public/500.html
+++ b/public/500.html
@@ -18,49 +18,100 @@
     margin: 4em auto 0;
   }
 
-  div.dialog > div {
+  div.dialog > .message {
     border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
     background-color: white;
     padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+    text-align: left;
   }
 
   h1 {
-    font-size: 100%;
-    color: #730E15;
+    font-size: 21px;
+    color: #2E394B;;
+    line-height: 1.5em;
+  }
+  h2 {
+    font-size: 18px;
+    color: #2E394B;;
     line-height: 1.5em;
   }
 
-  div.dialog > p {
+  div.dialog > .instructions {
     margin: 0 0 1em;
-    padding: 1em;
+    padding: 7px 12% 0;
     background-color: #F7F7F7;
     border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+    border-top: 0;
+    color: #2E394B;
+
+  }
+
+  body {
+  margin: 0;
+  background:  #fff;
+  width: 100%;
+  height: 100%;
+  }
+
+  #main {
+  background: #fff;
+  position: absolute;
+  bottom: 0;
+  top: 0;
+  left: 0;
+  right: 0;
+  }
+
+  .masthead {
+  display: inline-block;
+  width: 100%;
+  height: auto;
+  padding: .2em 0;
+  /* Blue background color */
+  background-color: #2E394B;
+  }
+  .program {
+    color: #F1AB00;
+    font-size: 16px;
+    font-family: sans-serif;
+    font-weight: 100;
+    letter-spacing: 0.25em;
+    display: inline-block;
+    margin-top: 12px;
+    margin-bottom: 8px;
   }
   </style>
 </head>
 
 <body>
   <!-- This file lives in public/500.html -->
-  <div class="dialog">
-    <div>
-      <h1>We're sorry, but something went wrong.</h1>
+  <div id="main">
+    <div class="masthead">
+      <div>
+        <p class="program">CLEANASSIST.ORG</p>
+      </div>
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
+    <div class="dialog">
+      <div class="message">
+        <h1>Something has gone wrong. We're sorry!</h1>
+        <p>We'll be looking into the problem and fixing it shortly.</p>
+      </div>
+      <div class="instructions" style="text-align:left">
+        <h3>Here's what to do:</h3>
+        <ul>
+          <li>
+            <b>If you have not submitted an application yet:</b>
+            <p>You can always use <a href="https://www.mybenefitscalwin.org/">MyBenefitsCalWIN.</a>It's long, but if you submit an application at 15% complete *and* upload verification documents, your client will have a good shot at enrolling.</p>
+          </li>
+          <li>
+            <b>If you had already submitted an application, but are trying to submit verificaiton documents:</b>
+            <p>Email the documents to <a href="mailto:food@sfgov.org">food@sfgov.org</a>. In the subject line, write "Pending Intake for [Applicant Name]". In the body of the email, describe the attached couments, and state that the application was submitted on today's date and time via "Clean".</p>
+          </li>
+        </ul>
+      </div>
+    </div>
   </div>
 </body>
 </html>

--- a/public/500.html
+++ b/public/500.html
@@ -110,6 +110,7 @@
             <p>Email the documents to <a href="mailto:food@sfgov.org">food@sfgov.org</a>. In the subject line, write "Pending Intake for [Applicant Name]". In the body of the email, describe the attached couments, and state that the application was submitted on today's date and time via "Clean".</p>
           </li>
         </ul>
+        <p>Need help right away? Get in touch with us at <a href="mailto:health-lab@codeforamerica.org">health-lab@codeforamerica.org</a>.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This PR does nothing but:
- Closes #261 
- Change the markup and styles of the 404 and 500 error pages, located and served according to their Rails defaults.
- Offers v1 copywriting. These should get more personable and friendly—but for now, they offer the instructions to those that need them, as well as a route to get in touch with us.
