### PR TITLE
Make all tests pass, add integration testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: ruby
+rvm:
+  - "2.1.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
 language: ruby
 rvm:
   - "2.1.5"
+addons:
+  postgresql: "9.3"
+before_script:
+  - psql -c 'create database "calfresh-and-so-clean_test";' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,10 @@ rvm:
   - "2.1.5"
 addons:
   postgresql: "9.3"
+before_install:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
 before_script:
   - psql -c 'create database "calfresh-and-so-clean_test";' -U postgres
+script:
+  - "xvfb-run -a bundle exec rspec spec"

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ group :development, :test do
   gem 'pry'
 
   gem 'capybara'
+  gem 'capybara-webkit'
 
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,9 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    capybara-webkit (1.4.1)
+      capybara (>= 2.3.0, < 2.5.0)
+      json
     climate_control (0.0.3)
       activesupport (>= 3.0)
     coderay (1.1.0)
@@ -202,6 +205,7 @@ DEPENDENCIES
   airbrake
   byebug
   capybara
+  capybara-webkit
   climate_control
   coffee-rails (~> 4.1.0)
   jbuilder (~> 2.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -141,7 +141,10 @@ class ApplicationController < ActionController::Base
       birth_year = date_of_birth_array[2]
       if birth_year.length == 4
         input_for_writer[:date_of_birth] = date_of_birth_array[0..1].join('/') + "/#{birth_year[-2..-1]}"
+      else
+        input_for_writer[:date_of_birth] = session[:date_of_birth]
       end
+      input_for_writer.delete('date_of_birth')
     end
     input_for_writer[:name_page3] = session[:name]
     input_for_writer[:ssn_page3] = session[:ssn]

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -409,13 +409,11 @@ EOF
 
       # Pending more mocking
       it 'adds application as attachment' do
-      pending
-        expect(fake_sendgrid_mail).to have_received(:add_attachment).with('/tmp/fakefinal.pdf')
+        expect(fake_sendgrid_mail).to have_received(:add_attachment).with('/tmp/fakehexvalue.zip')
       end
 
       # Pending more mocking
       it 'sends an email' do
-      pending
         expect(fake_sendgrid_client).to have_received(:send).with(fake_sendgrid_mail)
       end
     end

--- a/spec/feature_spec_helper.rb
+++ b/spec/feature_spec_helper.rb
@@ -1,3 +1,4 @@
 require 'rails_helper'
 require 'capybara/rails'
 
+Capybara.javascript_driver = :webkit

--- a/spec/features/all_features_spec.rb
+++ b/spec/features/all_features_spec.rb
@@ -8,57 +8,55 @@ feature 'User goes to root URL' do
   end
 end
 
-feature 'User leaves required fields empty' do
-  pending
+feature 'User leaves required fields empty', :js => true do
   scenario 'the error message is shown to the user to fill in those fields before continuing' do
     visit '/application/basic_info?'
-
+      expect(page.current_path).to eq('/application/basic_info')
       fill_in('name', with: '')
       fill_in('date_of_birth', with: '')
       click_on('Next Step')
-      #  This test is not complete and remains pending.
+      expect(page.current_path).to eq('/application/basic_info')
+      expect(page).to have_content('Name is required to apply')
+      expect(page).to have_content('Please provide your date of birth in the format described')
   end
 end
 
-
 feature 'User goes through full application (up to review and submit)' do
-  #  This test is pending DG's 
-  pending
-  scenario 'it all works!' do
+  scenario 'with basic interactions' do
     visit '/application/basic_info?'
       fill_in 'name', with: 'Hot Snakes'
       fill_in 'date_of_birth', with: "01/01/2000"
       click_button 'Next Step'
-      #  I don't like having tests dependent on copywriting, and I don't think they add value, except while writing.
-      expect(page).to have_content('Contact information')
+      expect(page.current_path).to eq('/application/contact_info')
       fill_in 'home_phone_number', with: "5555555555"
       fill_in 'email', with: "hotsnakes@gmail.com"
       fill_in 'home_address', with: "2015 Market Street"
       fill_in 'home_zip_code', with: "94122"
       click_on('Next Step')
-      expect(page).to have_content('Personal information')
+      expect(page.current_path).to eq('/application/sex_and_ssn')
       fill_in 'ssn', with: "000000000"
       choose('no-answer')
       click_on('Next Step')
-      expect(page).to have_content("Would you like to apply for Medi-Cal?")
+      expect(page.current_path).to eq('/application/medical')
       choose('no')
       click_on('Next Step')
-      expect(page).to have_content("When do you prefer your interview?")
+      expect(page.current_path).to eq('/application/interview')
       check('monday')
       check('friday')
       check('mid-morning')
       check('late-afternoon')
       click_on('Next Step')
-      expect(page).to have_content("Do you buy and cook food with anyone?")
+      expect(page.current_path).to eq('/application/household_question')
       click_link('Yes')
-      expect(page).to have_content("Household member information")
+      expect(page.current_path).to eq('/application/additional_household_member')
       fill_in 'their_name', with: 'Hot Snakes'
       fill_in 'their_date_of_birth', with: "01/01/2000"
       fill_in 'their_ssn', with: "000000000"
       choose('male')
       click_on('Next Step')
       expect(page).to have_content("Do you buy and cook food with anyone?")
+      expect(page.current_path).to eq('/application/household_question')
       click_link('No')
-      expect(page).to have_content("Confirm and submit")
+      expect(page.current_path).to eq('/application/review_and_submit')
   end
 end


### PR DESCRIPTION
- Modifies controller tests to mock email dependencies and therefore pass with the switch away from fax ( closes #310 )
- Sets up basic acceptance/integration testing ("smoke tests") and adds a few simple test paths
- Completes the basic "test hug" we wanted to do ( closes #219 for now; will open new issues for new passes/next steps ) This does _not_ implement major refactoring, but provides a test harness for it (new issues will be opened for that.)
- Adds Travis for continuous integration (after some fussing) ( #221 )
