### PR TITLE
Copy Overhaul

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -103,7 +103,15 @@ body {
 	margin: 0;
 	width: 100%;
 	height: 100%;
+	background-color: $blue-dark;
+}
+
+.main {
 	background-color: $background;
+	width: 100%;
+	height: 100%;
+	display: inline-block;
+	margin-top: -4px;
 }
 
 .masthead {
@@ -127,6 +135,20 @@ body {
 .circle {
 	/* in each context, redefine the equal height and width of the circle */
 	border-radius: 100%;
+}
+
+.footer {
+	width: 100%;
+	height: auto;
+	display: inline-block;
+}
+
+.footer-content {
+	display: inline-block;
+	@include form-type;
+	color: white;
+	font-size: 16px;
+	margin: 2em 0;
 }
 
 

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -141,15 +141,12 @@ body {
 	width: 100%;
 	height: auto;
 	display: inline-block;
+	padding: 2em 0;
 }
 
 .footer-content {
-	display: inline-block;
-	@include form-type;
+    @include page-context-type;
 	color: white;
-	font-size: 16px;
-	width: 100%;
-	margin: 1em 0;
 }
 
 

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -9,6 +9,14 @@
 
 /*================================*/
 
+/* Z INDICES */
+
+$zIndex-1:   100;
+$zIndex-2:   200;
+$zIndex-3:   300;
+
+/*================================*/
+
 /* C O L O R S */
 
 /* Highly used colors */
@@ -111,7 +119,7 @@ body {
 	width: 100%;
 	height: 100%;
 	display: inline-block;
-	margin-top: -4px;
+	margin-top: -.3em;
 }
 
 .masthead {
@@ -121,6 +129,7 @@ body {
 	padding: .2em 0;
 	background-color: white;
 	border-bottom: 1px solid $gray-light;
+	z-index: $zIndex-2;
 }
 
 .brand {

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -119,7 +119,7 @@ body {
 	width: 100%;
 	height: 100%;
 	display: inline-block;
-	margin-top: -.3em;
+	margin-top: -.4em;
 }
 
 .masthead {

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -120,6 +120,7 @@ body {
 	height: 100%;
 	display: inline-block;
 	margin-top: -.4em;
+	border-top: 1px solid $gray-light;
 }
 
 .masthead {

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -274,6 +274,7 @@ body {
 	box-shadow: none;
 }
 
+
 /* Form errors*/
 
 .parsley-required {
@@ -512,6 +513,10 @@ input.disabled {
 /* Medium devices (desktops, 992px and up) */
 /* Rename this back to @screen-md-min when we move to SCSS*/
 @media (min-width: 992px) {
+/* form control short, for things like ZIP code*/
+	.short {
+		width: 50%
+	}
 }
 
 /* Large devices (large desktops, 1200px and up) */

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -130,6 +130,10 @@ body {
 	margin: .5em 0;
 }
 
+.form {
+	margin-bottom: 2em;
+}
+
 /* Icons and Shapes */
 
 .circle {
@@ -243,6 +247,11 @@ body {
 	padding: .5em 0;
 }
 
+.btn-form-group {
+	padding-left: 1em;
+	padding-right: 1em;
+}
+
 /* form-controls, by position in a stack. */
 /* There can only be one top and one bottom, but there can be many middles.*/
 
@@ -340,7 +349,7 @@ input[type="radio"] {
 	height: 3em;
 	line-height: 2.5em;
 	border: 1px solid $gray-light;
-	width: 95%;
+	width: 85%;
 }
 
 .form-button.active {
@@ -463,8 +472,18 @@ input.disabled {
 	opacity: .85;
 }
 
+.page-footer {
+    border-top: 1px solid #eee;
+    margin-top: 1em;
+}
+
 .page-footer .or {
 	text-align: center;
+}
+
+.page-footer-content {
+	padding-left: 0;
+	padding-right: 0;
 }
 
 .footer-question {
@@ -501,9 +520,11 @@ input.disabled {
 	.step-explanation {
 		text-align: center;
 	}
-	.next-step {
-		margin: 1em 25% 2em 25%;
+	.start-btn {
 		width: 50%;
+		margin: 2em 0;
+	}
+	.footer {
 	}
 }
 

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -148,7 +148,8 @@ body {
 	@include form-type;
 	color: white;
 	font-size: 16px;
-	margin: 2em 0;
+	width: 100%;
+	margin: 1em 0;
 }
 
 

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -515,7 +515,7 @@ input.disabled {
 @media (min-width: 992px) {
 /* form control short, for things like ZIP code*/
 	.short {
-		width: 50%
+		width: 33%
 	}
 }
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,7 +15,10 @@ class ApplicationController < ActionController::Base
 
   def basic_info_submit
     session[:name] = params[:name]
-    session[:date_of_birth] = params[:date_of_birth]
+    session[:home_address] = params[:home_address]
+    session[:home_zip_code] = params[:home_zip_code]
+    session[:home_city] = params[:home_city]
+    session[:home_state] = params[:home_state]
     redirect_to '/application/contact_info'
   end
 
@@ -26,10 +29,6 @@ class ApplicationController < ActionController::Base
   def contact_info_submit
     session[:home_phone_number] = params[:home_phone_number]
     session[:email] = params[:email]
-    session[:home_address] = params[:home_address]
-    session[:home_zip_code] = params[:home_zip_code]
-    session[:home_city] = params[:home_city]
-    session[:home_state] = params[:home_state]
     session[:primary_language] = params[:primary_language]
     redirect_to '/application/sex_and_ssn'
   end
@@ -49,6 +48,7 @@ class ApplicationController < ActionController::Base
       else
         ""
     end
+    session[:date_of_birth] = params[:date_of_birth]
     session[:ssn] = params[:ssn]
     session[:sex] = sex
     redirect_to '/application/interview'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,4 @@
-class ApplicationController < ActionController::Base
+ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   #protect_from_forgery with: :exception

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -116,7 +116,10 @@ class ApplicationController < ActionController::Base
       sex: sex
     }
     session[:additional_household_members] << hash_for_person
-    redirect_to '/application/household_question'
+    redirect_to '/application/additional_household_question'
+  end
+
+  def additional_household_question
   end
 
   def review_and_submit

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -51,22 +51,6 @@ class ApplicationController < ActionController::Base
     session[:date_of_birth] = params[:date_of_birth]
     session[:ssn] = params[:ssn]
     session[:sex] = sex
-    redirect_to '/application/interview'
-  end
-
-  def interview
-  end
-
-  def interview_submit
-    selected_times = params.select do |key, value|
-      value == "on"
-    end.keys
-    underscored_selections = selected_times.map do  |t|
-      t.gsub("-","_")
-    end
-    underscored_selections.each do |selection|
-      session["interview_#{selection}"] = 'Yes'
-    end
     redirect_to '/application/household_question'
   end
 
@@ -120,6 +104,22 @@ class ApplicationController < ActionController::Base
   end
 
   def additional_household_question
+  end
+
+  def interview
+  end
+
+  def interview_submit
+    selected_times = params.select do |key, value|
+      value == "on"
+    end.keys
+    underscored_selections = selected_times.map do  |t|
+      t.gsub("-","_")
+    end
+    underscored_selections.each do |selection|
+      session["interview_#{selection}"] = 'Yes'
+    end
+    redirect_to '/application/review_and_submit'
   end
 
   def review_and_submit

--- a/app/views/application/additional_household_member.erb
+++ b/app/views/application/additional_household_member.erb
@@ -1,6 +1,6 @@
 <form name="additional_household_member" action="/application/additional_household_member" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1" data-parsley-validate>
-  <h2 class="page-header">Tell us about one of the people you live with</h2>
-  <p class="page-context">Have more than one person in your family or household? That's ok&mdash;you'll provide information on each of them, one at a time. If you don't have their social security numbers, that's ok too&mdash;but you will need their names and dates of birth.</p>
+  <h2 class="page-header">Information about people you live with</h2>
+  <p class="page-context">Provide information about your family or household members, one at a time. If you don't have their social security numbers, that's ok&mdash;but you will need to provide their names and dates of birth.</p>
   <div class="form-group">
     <label for="their-name" class="form-label">Their full name</label>
     <!-- ID and name do not match :/ their_name and their-name -->

--- a/app/views/application/additional_household_member.erb
+++ b/app/views/application/additional_household_member.erb
@@ -1,6 +1,7 @@
 <form name="additional_household_member" action="/application/additional_household_member" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1" data-parsley-validate>
-  <h2 class="page-header">Household member information</h2>
-  <p class="page-context">We need you to provide personal information for each individual you cook and prepare food with. If you don't have all of the information below, that's ok. Provide what you know, and Human Services Agency staff will ask you for additional information during your interview.</p>
+  <h2 class="page-header">Tell us about one of the other people in your household</h2>
+  <p class="page-context">We need you to provide personal information for each adult or child in your family, or roommates that you cook and share food with.</p>
+  <p class="page-context">If you don't have all of the information below, that's ok. Provide what you know, and Human Services Agency staff will ask you for additional information during your interview.</p>
   <div class="form-group">
     <label for="their-name" class="form-label">Their full name</label>
     <!-- ID and name do not match :/ their_name and their-name -->
@@ -13,17 +14,17 @@
   </div>
   <div class="form-group" data-toggle="buttons">
     <label class="form-label">Choose a sex</label>
-    <div class="col-lg-4 form-button-col">
+    <div class="col-md-4 form-button-col">
       <button class="btn form-button">
         <input type="radio" name="Female" id="female">Female
       </button>
     </div>
-    <div class="col-lg-4 form-button-col">
+    <div class="col-md-4 form-button-col">
       <button class="btn form-button">
         <input type="radio" name="Male" id="male">Male
       </button>
     </div>
-    <div class="col-lg-4 form-button-col">
+    <div class="col-md-4 form-button-col">
       <button class="btn form-button">
         <!-- Name and ID don't match :/ NoAnswer and no-answer -->
         <input type="radio" name="options" name="NoAnswer" id="no-answer">No answer

--- a/app/views/application/additional_household_member.erb
+++ b/app/views/application/additional_household_member.erb
@@ -1,6 +1,5 @@
 <form name="additional_household_member" action="/application/additional_household_member" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1" data-parsley-validate>
   <h2 class="page-header">Tell us about one of the other people in your household</h2>
-  <p class="page-context">If you don't have all of the information below, that's ok. Provide what you know, and Human Services Agency staff will ask you for additional information during your interview.</p>
   <div class="form-group">
     <label for="their-name" class="form-label">Their full name</label>
     <!-- ID and name do not match :/ their_name and their-name -->
@@ -9,6 +8,7 @@
     <!-- name and ID do not match :/ their_date_of_birth and date_of_birth -->
     <input type="text" class="form-control" name="their_date_of_birth" id="date_of_birth" placeholder="MM/DD/YY" required required data-parsley-required-message="Please their date of birth. Note the date format described" data-parsley-pattern="^(?:(?:(?:0?[13578]|1[02])(\/|-|\.)31)\1|(?:(?:0?[1,3-9]|1[0-2])(\/|-|\.)(?:29|30)\2))(?:(?:1[6-9]|[2-9]\d)?\d{2})$|^(?:0?2(\/|-|\.)29\3(?:(?:(?:1[6-9]|[2-9]\d)?(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00))))$|^(?:(?:0?[1-9])|(?:1[0-2]))(\/|-|\.)(?:0?[1-9]|1\d|2[0-8])\4(?:(?:1[6-9]|[2-9]\d)?\d{2})$">
     <label for="their_ssn" class="form-label">Their social security number</label>
+    <p class="form-context">If you don't know their social security number, that's ok. You can provide this information to HSA staff later.</p>
     <input type="tel" class="form-control" name="their_ssn" id="their_ssn">
   </div>
   <div class="form-group" data-toggle="buttons">

--- a/app/views/application/additional_household_member.erb
+++ b/app/views/application/additional_household_member.erb
@@ -7,11 +7,13 @@
     <label for="date_of_birth" class="form-label">Their date of birth</label>
     <!-- name and ID do not match :/ their_date_of_birth and date_of_birth -->
     <input type="text" class="form-control" name="their_date_of_birth" id="date_of_birth" placeholder="MM/DD/YY" required required data-parsley-required-message="Please their date of birth. Note the date format described" data-parsley-pattern="^(?:(?:(?:0?[13578]|1[02])(\/|-|\.)31)\1|(?:(?:0?[1,3-9]|1[0-2])(\/|-|\.)(?:29|30)\2))(?:(?:1[6-9]|[2-9]\d)?\d{2})$|^(?:0?2(\/|-|\.)29\3(?:(?:(?:1[6-9]|[2-9]\d)?(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00))))$|^(?:(?:0?[1-9])|(?:1[0-2]))(\/|-|\.)(?:0?[1-9]|1\d|2[0-8])\4(?:(?:1[6-9]|[2-9]\d)?\d{2})$">
+  </div>
+  <div class="form-group">
     <label for="their_ssn" class="form-label">Their social security number</label>
     <p class="form-context">If you don't know their social security number, that's ok. You can provide this information to HSA staff later.</p>
     <input type="tel" class="form-control" name="their_ssn" id="their_ssn">
   </div>
-  <div class="form-group" data-toggle="buttons">
+  <div class="row btn-form-group form-group" data-toggle="buttons">
     <label class="form-label">Choose a sex</label>
     <div class="col-md-4 form-button-col">
       <button class="btn form-button">
@@ -31,7 +33,9 @@
     </div>
   </div>
   <div class="page-footer">
-    <input class="btn next-step" type="submit" value="Next Step">
+    <div class="page-footer-content col-md-4 col-md-offset-8">
+      <input class="btn next-step" type="submit" value="Next Step">
+    </div>
   </div>
 </form>
 <script>

--- a/app/views/application/additional_household_member.erb
+++ b/app/views/application/additional_household_member.erb
@@ -7,7 +7,7 @@
     <input type="text" class="form-control" name="their_name" id="their-name" required required data-parsley-required-message="Please provide their full name to move forward!" autofocus="autofocus"\>
     <label for="date_of_birth" class="form-label">Their date of birth</label>
     <!-- name and ID do not match :/ their_date_of_birth and date_of_birth -->
-    <input type="text" class="form-control" name="their_date_of_birth" id="date_of_birth" placeholder="MM/DD/YY" required required data-parsley-required-message="Please their date of birth. Note the date format described" data-parsley-pattern="^(?:(?:(?:0?[13578]|1[02])(\/|-|\.)31)\1|(?:(?:0?[1,3-9]|1[0-2])(\/|-|\.)(?:29|30)\2))(?:(?:1[6-9]|[2-9]\d)?\d{2})$|^(?:0?2(\/|-|\.)29\3(?:(?:(?:1[6-9]|[2-9]\d)?(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00))))$|^(?:(?:0?[1-9])|(?:1[0-2]))(\/|-|\.)(?:0?[1-9]|1\d|2[0-8])\4(?:(?:1[6-9]|[2-9]\d)?\d{2})$">
+    <input type="text" class="form-control" name="their_date_of_birth" id="date_of_birth" placeholder="MM/DD/YY" required required data-parsley-required-message="Please provide their date of birth, in the format shown above." data-parsley-pattern="^(?:(?:(?:0?[13578]|1[02])(\/|-|\.)31)\1|(?:(?:0?[1,3-9]|1[0-2])(\/|-|\.)(?:29|30)\2))(?:(?:1[6-9]|[2-9]\d)?\d{2})$|^(?:0?2(\/|-|\.)29\3(?:(?:(?:1[6-9]|[2-9]\d)?(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00))))$|^(?:(?:0?[1-9])|(?:1[0-2]))(\/|-|\.)(?:0?[1-9]|1\d|2[0-8])\4(?:(?:1[6-9]|[2-9]\d)?\d{2})$">
   </div>
   <div class="form-group">
     <label for="their_ssn" class="form-label">Their social security number</label>

--- a/app/views/application/additional_household_member.erb
+++ b/app/views/application/additional_household_member.erb
@@ -1,5 +1,6 @@
 <form name="additional_household_member" action="/application/additional_household_member" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1" data-parsley-validate>
-  <h2 class="page-header">Tell us about one of the other people in your household</h2>
+  <h2 class="page-header">Tell us about one of the people you live with</h2>
+  <p class="page-context">Have more than one person in your family or household? That's ok&mdash;you'll provide information on each of them, one at a time. If you don't have their social security numbers, that's ok too&mdash;but you will need their names and dates of birth.</p>
   <div class="form-group">
     <label for="their-name" class="form-label">Their full name</label>
     <!-- ID and name do not match :/ their_name and their-name -->

--- a/app/views/application/additional_household_member.erb
+++ b/app/views/application/additional_household_member.erb
@@ -1,6 +1,5 @@
 <form name="additional_household_member" action="/application/additional_household_member" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1" data-parsley-validate>
   <h2 class="page-header">Tell us about one of the other people in your household</h2>
-  <p class="page-context">We need you to provide personal information for each adult or child in your family, or roommates that you cook and share food with.</p>
   <p class="page-context">If you don't have all of the information below, that's ok. Provide what you know, and Human Services Agency staff will ask you for additional information during your interview.</p>
   <div class="form-group">
     <label for="their-name" class="form-label">Their full name</label>

--- a/app/views/application/additional_household_member.erb
+++ b/app/views/application/additional_household_member.erb
@@ -5,10 +5,10 @@
   <div class="form-group">
     <label for="their-name" class="form-label">Their full name</label>
     <!-- ID and name do not match :/ their_name and their-name -->
-    <input type="text" class="form-control" name="their_name" id="their-name" required required data-parsley-required-message="Name is required to apply" autofocus="autofocus"\>
+    <input type="text" class="form-control" name="their_name" id="their-name" required required data-parsley-required-message="Please provide their full name to move forward!" autofocus="autofocus"\>
     <label for="date_of_birth" class="form-label">Their date of birth</label>
     <!-- name and ID do not match :/ their_date_of_birth and date_of_birth -->
-    <input type="text" class="form-control" name="their_date_of_birth" id="date_of_birth" placeholder="MM/DD/YY" required required data-parsley-required-message="Please provide your date of birth in the format described" data-parsley-pattern="^(?:(?:(?:0?[13578]|1[02])(\/|-|\.)31)\1|(?:(?:0?[1,3-9]|1[0-2])(\/|-|\.)(?:29|30)\2))(?:(?:1[6-9]|[2-9]\d)?\d{2})$|^(?:0?2(\/|-|\.)29\3(?:(?:(?:1[6-9]|[2-9]\d)?(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00))))$|^(?:(?:0?[1-9])|(?:1[0-2]))(\/|-|\.)(?:0?[1-9]|1\d|2[0-8])\4(?:(?:1[6-9]|[2-9]\d)?\d{2})$">
+    <input type="text" class="form-control" name="their_date_of_birth" id="date_of_birth" placeholder="MM/DD/YY" required required data-parsley-required-message="Please their date of birth. Note the date format described" data-parsley-pattern="^(?:(?:(?:0?[13578]|1[02])(\/|-|\.)31)\1|(?:(?:0?[1,3-9]|1[0-2])(\/|-|\.)(?:29|30)\2))(?:(?:1[6-9]|[2-9]\d)?\d{2})$|^(?:0?2(\/|-|\.)29\3(?:(?:(?:1[6-9]|[2-9]\d)?(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00))))$|^(?:(?:0?[1-9])|(?:1[0-2]))(\/|-|\.)(?:0?[1-9]|1\d|2[0-8])\4(?:(?:1[6-9]|[2-9]\d)?\d{2})$">
     <label for="their_ssn" class="form-label">Their social security number</label>
     <input type="tel" class="form-control" name="their_ssn" id="their_ssn">
   </div>

--- a/app/views/application/additional_household_member.erb
+++ b/app/views/application/additional_household_member.erb
@@ -7,7 +7,7 @@
     <input type="text" class="form-control" name="their_name" id="their-name" required required data-parsley-required-message="Name is required to apply" autofocus="autofocus"\>
     <label for="date_of_birth" class="form-label">Their date of birth</label>
     <!-- name and ID do not match :/ their_date_of_birth and date_of_birth -->
-    <input type="text" class="form-control" name="their_date_of_birth" id="date_of_birth" placeholder="MM/DD/YYYY" required required data-parsley-required-message="Please provide your date of birth in the format described" data-parsley-pattern="^(?:(?:(?:0?[13578]|1[02])(\/|-|\.)31)\1|(?:(?:0?[1,3-9]|1[0-2])(\/|-|\.)(?:29|30)\2))(?:(?:1[6-9]|[2-9]\d)?\d{2})$|^(?:0?2(\/|-|\.)29\3(?:(?:(?:1[6-9]|[2-9]\d)?(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00))))$|^(?:(?:0?[1-9])|(?:1[0-2]))(\/|-|\.)(?:0?[1-9]|1\d|2[0-8])\4(?:(?:1[6-9]|[2-9]\d)?\d{2})$">
+    <input type="text" class="form-control" name="their_date_of_birth" id="date_of_birth" placeholder="MM/DD/YY" required required data-parsley-required-message="Please provide your date of birth in the format described" data-parsley-pattern="^(?:(?:(?:0?[13578]|1[02])(\/|-|\.)31)\1|(?:(?:0?[1,3-9]|1[0-2])(\/|-|\.)(?:29|30)\2))(?:(?:1[6-9]|[2-9]\d)?\d{2})$|^(?:0?2(\/|-|\.)29\3(?:(?:(?:1[6-9]|[2-9]\d)?(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00))))$|^(?:(?:0?[1-9])|(?:1[0-2]))(\/|-|\.)(?:0?[1-9]|1\d|2[0-8])\4(?:(?:1[6-9]|[2-9]\d)?\d{2})$">
     <label for="their_ssn" class="form-label">Their social security number</label>
     <input type="tel" class="form-control" name="their_ssn" id="their_ssn">
   </div>

--- a/app/views/application/additional_household_question.erb
+++ b/app/views/application/additional_household_question.erb
@@ -1,15 +1,16 @@
 <form name="household_question" action="/application/additional_household_question" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
-  <h2 class="page-header">Thanks! Do any others live with you?</h2>
-  <p class="page-context">We need you to provide information for each member of your family or household that you buy and prepare food with or for.</p>
+  <h2 class="page-header">Do you need to document anyone else?</h2>
   <br>
   <div class="row form-group">
     <div class="col-md-6 form-button-col">
         <p class="form-context">Yes, I have another family or household member to document.</p>
+        <br>
         <a href="/application/additional_household_member" class="btn form-button" autofocus="autofocus">Yes</a>
     </div>
     <div class="col-md-6 form-button-col">
-        <p class="form-context">No, I have documented all others I live with.</p>
-        <a href="/application/review_and_submit" class="btn form-button">No</a>
+        <p class="form-context">No, I have documented all others I live with. Let's move on.</p>
+        <br>
+        <a href="/application/interview" class="btn form-button">No</a>
     </div>
   </div>
 </form>

--- a/app/views/application/additional_household_question.erb
+++ b/app/views/application/additional_household_question.erb
@@ -8,7 +8,7 @@
         <a href="/application/additional_household_member" class="btn form-button" autofocus="autofocus">Yes</a>
     </div>
     <div class="col-md-6 form-button-col">
-        <p class="form-context" style="padding: 1em 1em .5em 1em;">No, I have documented all others I live with. Let's move on.</p>
+        <p class="form-context" style="padding: 1em 1em .5em 1em;">No, I have documented all others I live with. Let's move on!</p>
         <br>
         <a href="/application/interview" class="btn form-button">No</a>
     </div>

--- a/app/views/application/additional_household_question.erb
+++ b/app/views/application/additional_household_question.erb
@@ -1,0 +1,18 @@
+<form name="household_question" action="/application/additional_household_question" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
+  <h2 class="page-header">Thanks! Do any others live with you?</h2>
+  <p class="page-context">We need you to provide information for each member of your family or household that you buy and prepare food with or for.</p>
+  <br>
+  <div class="row form-group">
+    <div class="col-md-6 form-button-col">
+        <p class="form-context">Yes, I have another family or household member to document.</p>
+        <a href="/application/additional_household_member" class="btn form-button" autofocus="autofocus">Yes</a>
+    </div>
+    <div class="col-md-6 form-button-col">
+        <p class="form-context">No, I have documented all others I live with.</p>
+        <a href="/application/review_and_submit" class="btn form-button">No</a>
+    </div>
+  </div>
+</form>
+<script>
+  $('.btn').button()
+</script>

--- a/app/views/application/additional_household_question.erb
+++ b/app/views/application/additional_household_question.erb
@@ -2,13 +2,13 @@
   <h2 class="page-header">Do you need to document anyone else?</h2>
   <br>
   <div class="row form-group">
-    <div class="col-md-6 form-button-col">
-        <p class="form-context">Yes, I have another family or household member to document.</p>
+    <div class="col-md-6 form-button-col" style="text-align: center;">
+        <p class="form-context" style="padding: 1em 1em .5em 1em;">Yes, I have another family or household member to document.</p>
         <br>
         <a href="/application/additional_household_member" class="btn form-button" autofocus="autofocus">Yes</a>
     </div>
     <div class="col-md-6 form-button-col">
-        <p class="form-context">No, I have documented all others I live with. Let's move on.</p>
+        <p class="form-context" style="padding: 1em 1em .5em 1em;">No, I have documented all others I live with. Let's move on.</p>
         <br>
         <a href="/application/interview" class="btn form-button">No</a>
     </div>

--- a/app/views/application/basic_info.erb
+++ b/app/views/application/basic_info.erb
@@ -6,7 +6,7 @@
   </div>
   <div class="form-group">
     <label for="home_address" class="form-label">Your street address</label>
-    <p class="form-context">Confirm that you live in San Francisco, and let HSA know where to mail you important information about your benefits.</p>
+    <p class="form-context">Confirm that you live in San Francisco, and let the Human Services Agency (HSA) know where to mail you important information about your benefits.</p>
     <input id="home_address" type="text" class="form-control" name="home_address" required required data-parsley-required-message="Confirm that you live in San Francisco by providing your street address." \>
     <label for="home_zip_code" class="form-label">ZIP code</label>
     <input id="home_zip_code" type="tel" class="form-control short" name="home_zip_code" required required data-parsley-required-message="We need your ZIP code too!">

--- a/app/views/application/basic_info.erb
+++ b/app/views/application/basic_info.erb
@@ -2,12 +2,12 @@
   <h2 class="page-header">Basic information</h2>
 	<div class="form-group">
     <label for="name" class="form-label">Your full name</label>
-		<input type="text" class="form-control" name="name" id="name" required required data-parsley-required-message="Name is required to apply" autofocus="autofocus">
+		<input type="text" class="form-control" name="name" id="name" required required data-parsley-required-message="Provide your full name to get started!" autofocus="autofocus">
     <label for="home_address" class="form-label">Your street address</label>
     <p class="form-context">HSA needs to confirm that you live in San Francisco, and know where to mail you important information.</p>
-    <input id="home_address" type="text" class="form-control" name="home_address" required required data-parsley-required-message="Address is required to apply" \>
+    <input id="home_address" type="text" class="form-control" name="home_address" required required data-parsley-required-message="Confirm that you live in San Francisco by providing your street address." \>
     <label for="home_zip_code" class="form-label">ZIP code</label>
-    <input id="home_zip_code" type="tel" class="form-control short" name="home_zip_code" required required data-parsley-required-message="ZIP code is required to apply">
+    <input id="home_zip_code" type="tel" class="form-control short" name="home_zip_code" required required data-parsley-required-message="We need your ZIP code too!">
     <input type="hidden" class="form-control" name="home_city" value="San Francisco">
     <input type="hidden" class="form-control" name="home_state" value="CA">
 	</div>

--- a/app/views/application/basic_info.erb
+++ b/app/views/application/basic_info.erb
@@ -1,10 +1,15 @@
 <form name="basic_info" action="/application/basic_info" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1 m-page scene_element scene_element--fadeinup" data-parsley-validate>
-  <h2 class="page-header">Get started</h2>
+  <h2 class="page-header">Basic information</h2>
 	<div class="form-group">
     <label for="name" class="form-label">Your full name</label>
 		<input type="text" class="form-control" name="name" id="name" required required data-parsley-required-message="Name is required to apply" autofocus="autofocus">
-    <label for="date_of_birth" class="form-label">Your date of birth</label>
-		<input type="text" class="form-control" name="date_of_birth" id="date_of_birth" placeholder="MM/DD/YY" required required data-parsley-required-message="Please provide your date of birth in the format described" data-parsley-pattern="^(?:(?:(?:0?[13578]|1[02])(\/|-|\.)31)\1|(?:(?:0?[1,3-9]|1[0-2])(\/|-|\.)(?:29|30)\2))(?:(?:1[6-9]|[2-9]\d)?\d{2})$|^(?:0?2(\/|-|\.)29\3(?:(?:(?:1[6-9]|[2-9]\d)?(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00))))$|^(?:(?:0?[1-9])|(?:1[0-2]))(\/|-|\.)(?:0?[1-9]|1\d|2[0-8])\4(?:(?:1[6-9]|[2-9]\d)?\d{2})$">
+    <label for="home_address" class="form-label">Street address</label>
+    <p class="form-context">in San Francisco, CA</p>
+    <input id="home_address" type="text" class="form-control" name="home_address" required required data-parsley-required-message="Address is required to apply" \>
+    <label for="home_zip_code" class="form-label">ZIP code</label>
+    <input id="home_zip_code" type="tel" class="form-control short" name="home_zip_code" required required data-parsley-required-message="ZIP code is required to apply">
+    <input type="hidden" class="form-control" name="home_city" value="San Francisco">
+    <input type="hidden" class="form-control" name="home_state" value="CA">
 	</div>
   <div class="page-footer">
     <input class="btn next-step" type="submit" value="Next Step">

--- a/app/views/application/basic_info.erb
+++ b/app/views/application/basic_info.erb
@@ -3,8 +3,10 @@
 	<div class="form-group">
     <label for="name" class="form-label">Your full name</label>
 		<input type="text" class="form-control" name="name" id="name" required required data-parsley-required-message="Provide your full name to get started!" autofocus="autofocus">
+  </div>
+  <div class="form-group">
     <label for="home_address" class="form-label">Your street address</label>
-    <p class="form-context">HSA needs to confirm that you live in San Francisco, and know where to mail you important information.</p>
+    <p class="form-context">Confirm that you live in San Francisco, and let HSA know where to mail you important information about your benefits.</p>
     <input id="home_address" type="text" class="form-control" name="home_address" required required data-parsley-required-message="Confirm that you live in San Francisco by providing your street address." \>
     <label for="home_zip_code" class="form-label">ZIP code</label>
     <input id="home_zip_code" type="tel" class="form-control short" name="home_zip_code" required required data-parsley-required-message="We need your ZIP code too!">
@@ -12,7 +14,9 @@
     <input type="hidden" class="form-control" name="home_state" value="CA">
 	</div>
   <div class="page-footer">
-    <input class="btn next-step" type="submit" value="Next Step">
+    <div class="page-footer-content col-md-4 col-md-offset-8">
+      <input class="btn next-step" type="submit" value="Next Step">
+    </div>
   </div>
 </form>
 

--- a/app/views/application/basic_info.erb
+++ b/app/views/application/basic_info.erb
@@ -4,7 +4,7 @@
     <label for="name" class="form-label">Your full name</label>
 		<input type="text" class="form-control" name="name" id="name" required required data-parsley-required-message="Name is required to apply" autofocus="autofocus">
     <label for="date_of_birth" class="form-label">Your date of birth</label>
-		<input type="text" class="form-control" name="date_of_birth" id="date_of_birth" placeholder="MM/DD/YYYY" required required data-parsley-required-message="Please provide your date of birth in the format described" data-parsley-pattern="^(?:(?:(?:0?[13578]|1[02])(\/|-|\.)31)\1|(?:(?:0?[1,3-9]|1[0-2])(\/|-|\.)(?:29|30)\2))(?:(?:1[6-9]|[2-9]\d)?\d{2})$|^(?:0?2(\/|-|\.)29\3(?:(?:(?:1[6-9]|[2-9]\d)?(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00))))$|^(?:(?:0?[1-9])|(?:1[0-2]))(\/|-|\.)(?:0?[1-9]|1\d|2[0-8])\4(?:(?:1[6-9]|[2-9]\d)?\d{2})$">
+		<input type="text" class="form-control" name="date_of_birth" id="date_of_birth" placeholder="MM/DD/YY" required required data-parsley-required-message="Please provide your date of birth in the format described" data-parsley-pattern="^(?:(?:(?:0?[13578]|1[02])(\/|-|\.)31)\1|(?:(?:0?[1,3-9]|1[0-2])(\/|-|\.)(?:29|30)\2))(?:(?:1[6-9]|[2-9]\d)?\d{2})$|^(?:0?2(\/|-|\.)29\3(?:(?:(?:1[6-9]|[2-9]\d)?(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00))))$|^(?:(?:0?[1-9])|(?:1[0-2]))(\/|-|\.)(?:0?[1-9]|1\d|2[0-8])\4(?:(?:1[6-9]|[2-9]\d)?\d{2})$">
 	</div>
   <div class="page-footer">
     <input class="btn next-step" type="submit" value="Next Step">

--- a/app/views/application/basic_info.erb
+++ b/app/views/application/basic_info.erb
@@ -3,8 +3,8 @@
 	<div class="form-group">
     <label for="name" class="form-label">Your full name</label>
 		<input type="text" class="form-control" name="name" id="name" required required data-parsley-required-message="Name is required to apply" autofocus="autofocus">
-    <label for="home_address" class="form-label">Street address</label>
-    <p class="form-context">in San Francisco, CA</p>
+    <label for="home_address" class="form-label">Your street address</label>
+    <p class="form-context">HSA needs to confirm that you live in San Francisco, and know where to mail you important information.</p>
     <input id="home_address" type="text" class="form-control" name="home_address" required required data-parsley-required-message="Address is required to apply" \>
     <label for="home_zip_code" class="form-label">ZIP code</label>
     <input id="home_zip_code" type="tel" class="form-control short" name="home_zip_code" required required data-parsley-required-message="ZIP code is required to apply">

--- a/app/views/application/contact_info.erb
+++ b/app/views/application/contact_info.erb
@@ -1,21 +1,23 @@
-<form name="contact_info" action="/application/contact_info" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1 m-page scene_element scene_element--fadeinup" data-parsley-validate>
-  <h2 class="page-header">Contact information</h2>
-  <p class="page-context">What's the best way to get in touch with you? Throughout your time receiving CalFresh, HSA will occasionally need to send you important information, or ask you to provide updates to your personal information.</p>
-  <div class="form-group">
-    <label for="home_phone-number" class="form-label">Phone number</label>
-    <p class="form-context">HSA staff will call you on this number to conduct a short interview after you submit your application.</p>
-    <input id="home_phone_number" type="tel" class="form-control" name="home_phone_number" autofocus="autofocus">
-    <label for="email" class="form-label">Email</label>
-    <input id="email" type="email" class="form-control" name="email">
-    <h3 class="form-label">Your preferred language</h3>
-    <p class="form-context">HSA will send you documents in the language of your choice.</p>
-    <select class="form-control solo" name="primary_language">
-      <% @language_options.each do |language| %>
-        <option value="<%= language %>"><%= language %></option>
-      <% end %>
-    </select>
-  </div>
-  <div class="page-footer">
-    <input class="btn next-step" type="submit" value="Next Step">
-  </div>
+<form name="contact_info" action="/application/contact_info" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1" data-parsley-validate>
+    <h2 class="page-header">Contact information</h2>
+    <p class="page-context">What's the best way to get in touch with you? Throughout your time receiving CalFresh, HSA will occasionally need to send you important information, or ask you to provide updates to your personal information.</p>
+    <div class="form-group">
+      <label for="home_phone-number" class="form-label">Phone number</label>
+      <p class="form-context">HSA staff will call you on this number to conduct a short interview after you submit your application.</p>
+      <input id="home_phone_number" type="tel" class="form-control" name="home_phone_number" autofocus="autofocus">
+      <label for="email" class="form-label">Email</label>
+      <input id="email" type="email" class="form-control" name="email">
+      <h3 class="form-label">Your preferred language</h3>
+      <p class="form-context">HSA will send you documents in the language of your choice.</p>
+      <select class="form-control solo" name="primary_language">
+        <% @language_options.each do |language| %>
+          <option value="<%= language %>"><%= language %></option>
+        <% end %>
+      </select>
+    </div>
+    <div class="page-footer">
+      <div class="page-footer-content col-md-4 col-md-offset-8">
+        <input class="btn next-step" type="submit" value="Next Step">
+      </div>
+    </div>
 </form>

--- a/app/views/application/contact_info.erb
+++ b/app/views/application/contact_info.erb
@@ -1,6 +1,6 @@
 <form name="contact_info" action="/application/contact_info" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1" data-parsley-validate>
     <h2 class="page-header">Contact information</h2>
-    <p class="page-context">Let HSA know how to get in touch with you. A few days after you submit your application, a staffperson will call you to review your case. Once you are enrolled and receiving CalFresh, HSA will periodically send important information to the address you provide.</p>
+    <p class="page-context">Let HSA know how to get in touch with you. A few days after you submit your application, a staffperson will call you to review your case. Once you are enrolled and receiving CalFresh, HSA will periodically send important information in the language of your choice.</p>
     <div class="form-group">
       <label for="home_phone-number" class="form-label">Phone number</label>
       <p class="form-context">HSA staff will call you on this number to conduct a short interview after you submit your application.</p>
@@ -8,7 +8,6 @@
       <label for="email" class="form-label">Email</label>
       <input id="email" type="email" class="form-control" name="email">
       <h3 class="form-label">Your preferred language</h3>
-      <p class="form-context">HSA will send you documents in the language of your choice.</p>
       <select class="form-control solo" name="primary_language">
         <% @language_options.each do |language| %>
           <option value="<%= language %>"><%= language %></option>

--- a/app/views/application/contact_info.erb
+++ b/app/views/application/contact_info.erb
@@ -1,11 +1,14 @@
 <form name="contact_info" action="/application/contact_info" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1 m-page scene_element scene_element--fadeinup" data-parsley-validate>
   <h2 class="page-header">Contact information</h2>
+  <p class="page-context">What's the best way to get in touch with you? Throughout your time receiving CalFresh, HSA will occasionally need to send you important information, or ask you to provide updates to your personal information.</p>
   <div class="form-group">
     <label for="home_phone-number" class="form-label">Phone number</label>
+    <p class="form-context">HSA staff will call you on this number to conduct a short interview after you submit your application.</p>
     <input id="home_phone_number" type="tel" class="form-control middle" name="home_phone_number" autofocus="autofocus">
     <label for="email" class="form-label">Email</label>
     <input id="email" type="email" class="form-control middle" name="email">
-    <h3 class="form-label">Your preferred language:</h3>
+    <h3 class="form-label">Your preferred language</h3>
+    <p class="form-context">HSA will send you documents in the language of your choice.</p>
     <select class="form-control solo" name="primary_language">
       <% @language_options.each do |language| %>
         <option value="<%= language %>"><%= language %></option>

--- a/app/views/application/contact_info.erb
+++ b/app/views/application/contact_info.erb
@@ -5,13 +5,6 @@
     <input id="home_phone_number" type="tel" class="form-control middle" name="home_phone_number" autofocus="autofocus">
     <label for="email" class="form-label">Email</label>
     <input id="email" type="email" class="form-control middle" name="email">
-    <label for="home_address" class="form-label">Street address</label>
-    <p class="form-context">in San Francisco, CA</p>
-    <input id="home_address" type="text" class="form-control middle" name="home_address" required required data-parsley-required-message="Address is required to apply" \>
-    <label for="home_zip_code" class="form-label">ZIP code</label>
-    <input id="home_zip_code" type="tel" class="form-control bottom" name="home_zip_code" required required data-parsley-required-message="ZIP code is required to apply">
-    <input type="hidden" class="form-control" name="home_city" value="San Francisco">
-    <input type="hidden" class="form-control" name="home_state" value="CA">
     <h3 class="form-label">Your preferred language:</h3>
     <select class="form-control solo" name="primary_language">
       <% @language_options.each do |language| %>

--- a/app/views/application/contact_info.erb
+++ b/app/views/application/contact_info.erb
@@ -1,6 +1,6 @@
 <form name="contact_info" action="/application/contact_info" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1" data-parsley-validate>
     <h2 class="page-header">Contact information</h2>
-    <p class="page-context">What's the best way to get in touch with you? Throughout your time receiving CalFresh, HSA will occasionally need to send you important information, or ask you to provide updates to your personal information.</p>
+    <p class="page-context">Let HSA know how to get in touch with you. While you are receiving CalFresh, staff will periodically send you important information and ask you to update your personal information.</p>
     <div class="form-group">
       <label for="home_phone-number" class="form-label">Phone number</label>
       <p class="form-context">HSA staff will call you on this number to conduct a short interview after you submit your application.</p>

--- a/app/views/application/contact_info.erb
+++ b/app/views/application/contact_info.erb
@@ -1,6 +1,6 @@
 <form name="contact_info" action="/application/contact_info" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1" data-parsley-validate>
     <h2 class="page-header">Contact information</h2>
-    <p class="page-context">Let HSA know how to get in touch with you. A few days after you submit your application, HSA staff will call you to review your case. Once you are enrolled and receiving CalFresh, HSA will periodically send you important information.</p>
+    <p class="page-context">Let HSA know how to get in touch with you. A few days after you submit your application, a staffperson will call you to review your case. Once you are enrolled and receiving CalFresh, HSA will periodically send important information to the address you provide.</p>
     <div class="form-group">
       <label for="home_phone-number" class="form-label">Phone number</label>
       <p class="form-context">HSA staff will call you on this number to conduct a short interview after you submit your application.</p>

--- a/app/views/application/contact_info.erb
+++ b/app/views/application/contact_info.erb
@@ -4,9 +4,9 @@
   <div class="form-group">
     <label for="home_phone-number" class="form-label">Phone number</label>
     <p class="form-context">HSA staff will call you on this number to conduct a short interview after you submit your application.</p>
-    <input id="home_phone_number" type="tel" class="form-control middle" name="home_phone_number" autofocus="autofocus">
+    <input id="home_phone_number" type="tel" class="form-control" name="home_phone_number" autofocus="autofocus">
     <label for="email" class="form-label">Email</label>
-    <input id="email" type="email" class="form-control middle" name="email">
+    <input id="email" type="email" class="form-control" name="email">
     <h3 class="form-label">Your preferred language</h3>
     <p class="form-context">HSA will send you documents in the language of your choice.</p>
     <select class="form-control solo" name="primary_language">

--- a/app/views/application/contact_info.erb
+++ b/app/views/application/contact_info.erb
@@ -1,6 +1,6 @@
 <form name="contact_info" action="/application/contact_info" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1" data-parsley-validate>
     <h2 class="page-header">Contact information</h2>
-    <p class="page-context">Let HSA know how to get in touch with you. While you are receiving CalFresh, staff will periodically send you important information and ask you to update your personal information.</p>
+    <p class="page-context">Let HSA know how to get in touch with you. A few days after you submit your application, HSA staff will call you to review your case. Once you are enrolled and receiving CalFresh, HSA will periodically send you important information.</p>
     <div class="form-group">
       <label for="home_phone-number" class="form-label">Phone number</label>
       <p class="form-context">HSA staff will call you on this number to conduct a short interview after you submit your application.</p>

--- a/app/views/application/document_instructions.erb
+++ b/app/views/application/document_instructions.erb
@@ -1,5 +1,5 @@
 <form name="confirmation" action="/application/confirmation" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
-	<h3 class="page-header">You're application has been submitted!</h3>
+	<h3 class="page-header">Your application has been submitted!</h3>
 	<p class="homepage-subheader">There are two more steps&mdash;you can start now.</p>
 	<div class="form-group">
 		<br>
@@ -26,8 +26,8 @@
 			</li>
 			<br>
 			<li>
-				<p class="form-label">Take a phone call from the Human Services Agency</p>
-				<p class="page-context"><b>In the next few days</b>, expect a phone call from SFHSA. Together, you'll walk through the application you submitted, and the documents you've sent in via email. During this conversation, staff will tell you whether or not you've qualified.</p>
+				<p class="form-label">Take a phone call from HSA staff</p>
+				<p class="page-context"><b>In the next few days</b>, expect a phone call from HSA. Together, you'll walk through the application you submitted, and the documents you've sent in via email. During this conversation, staff will tell you whether or not you've qualified.</p>
 			</li>
 		</ol>
 		<p class="homepage-subheader">Have questions? Don't hesitate to call Jake Solomon and the Clean Assist team at <strong>(510) 206-8727.</strong></p>

--- a/app/views/application/household_question.erb
+++ b/app/views/application/household_question.erb
@@ -1,13 +1,12 @@
 <form name="household_question" action="/application/household_question" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
-  <h2 class="page-header">Do you buy and cook food with anyone?</h2>
-  <p class="page-context">CalFresh supports nutrition for individuals and families. We need to know if you buy and cook food with anyone else. This includes roommates, adult family members, and children.</p>
+  <h2 class="page-header">Do others live with you?</h2>
+  <p class="page-context">CalFresh supports nutrition for individuals and families. Only include adult family members, children, and roommates that you share food and cooking with.</p>
   <br>
-  <div class="page-footer">
   <div class="row form-group">
-    <div class="col-lg-6 form-button-col">
+    <div class="col-md-6 form-button-col">
         <a href="/application/additional_household_member" class="btn form-button" autofocus="autofocus">Yes</a>
     </div>
-    <div class="col-lg-6 form-button-col">
+    <div class="col-md-6 form-button-col">
         <a href="/application/review_and_submit" class="btn form-button">No</a>
     </div>
   </div>

--- a/app/views/application/household_question.erb
+++ b/app/views/application/household_question.erb
@@ -1,6 +1,7 @@
 <form name="household_question" action="/application/household_question" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
-  <h2 class="page-header">Do others live with you?</h2>
-  <p class="page-context">CalFresh supports nutrition for individuals and families. Only include adult family members, children, and roommates that you share food and cooking with.</p>
+  <h2 class="page-header">Do you live with others?</h2>
+  <p class="page-context">CalFresh benefits support both individuals and families.The dollar amount of benefits you'll recieve is influenced by the number of people CalFresh needs to help. You'll need to provide personal information about each person you share food and cooking expenses with.</p>
+  <p class="page-context"><b>Only</b> include adult family members, children, and roommates that you buy groceries and eat with daily. Don't include roommates that live on their own budget.</p>
   <br>
   <div class="row form-group">
     <div class="col-md-6 form-button-col">

--- a/app/views/application/household_question.erb
+++ b/app/views/application/household_question.erb
@@ -1,6 +1,6 @@
 <form name="household_question" action="/application/household_question" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
   <h2 class="page-header">Do you live with others?</h2>
-  <p class="page-context">CalFresh benefits support both individuals and families. The amount of benefits you'll recieve is influenced by the number of people the benefits need to support. You'll need to provide personal information about each person you share food and cooking expenses with.</p>
+  <p class="page-context">CalFresh supports both individuals and families. The amount of benefits you'll recieve is influenced by the number of people the benefits need to support. You'll need to provide personal information about each person you share food and cooking expenses with.</p>
   <p class="page-context"><b>Only</b> include adult family members, children, and roommates that you buy groceries and eat with daily. Don't include roommates that live on their own budget.</p>
   <br>
   <div class="row form-group">

--- a/app/views/application/household_question.erb
+++ b/app/views/application/household_question.erb
@@ -1,6 +1,6 @@
 <form name="household_question" action="/application/household_question" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
   <h2 class="page-header">Do you live with others?</h2>
-  <p class="page-context">CalFresh supports both individuals and families. The amount of benefits you'll recieve is influenced by the number of people the benefits need to support. You'll need to provide personal information about each person you share food and cooking expenses with.</p>
+  <p class="page-context">CalFresh supports both individuals and families. The amount of benefits you'll receive is influenced by the number of people the benefits need to support. You'll need to provide personal information about each person you share food and cooking expenses with.</p>
   <p class="page-context"><b>Only</b> include adult family members, children, and roommates that you buy groceries and eat with daily. Don't include roommates that live on their own budget.</p>
   <br>
   <div class="row form-group">

--- a/app/views/application/household_question.erb
+++ b/app/views/application/household_question.erb
@@ -1,6 +1,6 @@
 <form name="household_question" action="/application/household_question" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
   <h2 class="page-header">Do you live with others?</h2>
-  <p class="page-context">CalFresh benefits support both individuals and families.The dollar amount of benefits you'll recieve is influenced by the number of people CalFresh needs to help. You'll need to provide personal information about each person you share food and cooking expenses with.</p>
+  <p class="page-context">CalFresh benefits support both individuals and families. The amount of benefits you'll recieve is influenced by the number of people the benefits need to support. You'll need to provide personal information about each person you share food and cooking expenses with.</p>
   <p class="page-context"><b>Only</b> include adult family members, children, and roommates that you buy groceries and eat with daily. Don't include roommates that live on their own budget.</p>
   <br>
   <div class="row form-group">

--- a/app/views/application/household_question.erb
+++ b/app/views/application/household_question.erb
@@ -8,7 +8,7 @@
         <a href="/application/additional_household_member" class="btn form-button" autofocus="autofocus">Yes</a>
     </div>
     <div class="col-md-6 form-button-col">
-        <a href="/application/review_and_submit" class="btn form-button">No</a>
+        <a href="/application/interview" class="btn form-button">No</a>
     </div>
   </div>
 </form>

--- a/app/views/application/index.erb
+++ b/app/views/application/index.erb
@@ -1,29 +1,29 @@
 <form action="/application/basic_info" method="get" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
   <div class="homepage-message">
-    <h2 class="homepage-headline">You may be eligible for hundreds of dollars for food and groceries</h2>
+    <h2 class="homepage-headline">You may be eligible for hundreds of dollars for food and groceries each year</h2>
     <input class="btn next-step" type="submit" value="Start your application" autofocus="autofocus">
     <h3 class="homepage-subheader">Apply online in 10 minutes</h3>
   </div>
   <div class="row steps-to-enroll" style="margin-top: 0; padding-top: 0;">
-    <div class="col-lg-4">
+    <div class="col-md-4">
       <div class="step-to-enroll">
         <div class="circle step-to-enroll-icon">1</div>
-        <h4 class="step-title">Submit online</h4>
-        <p class="step-explanation">With Clean Assist, you can apply for CalFresh in under 10 minutes. It's easy. If you have documents on hand, you can send them in with your application.</p>
+        <h4 class="step-title">Apply online</h4>
+        <p class="step-explanation">You can apply for CalFresh in under 10 minutes. If you have documents on hand, you can email them into after submitting your application.</p>
       </div>
     </div>
-    <div class="col-lg-4 ">
+    <div class="col-md-4">
       <div class="step-to-enroll">
         <div class="circle step-to-enroll-icon">2</div>
         <h4 class="step-title">Take a phone call</h4>
-        <p class="step-explanation">After you submit your application, take a quick phone call with Human Services Agency staff, and walk through the details of your case. Clean Assist will help you schedule a time that works for you.</p>
+        <p class="step-explanation">Take a quick phone call with Human Services Agency (HSA) staff to review your application.</p>
       </div>
     </div>
-    <div class="col-lg-4">
+    <div class="col-md-4">
       <div class="step-to-enroll">
         <div class="circle step-to-enroll-icon">3</div>
-        <h4 class="step-title">Email documents</h4>
-        <p class="step-explanation">To receive benefits, you'll need to document your income and expenses. Send in photos of bills, paystubs and other verification documents to finalize your application.</p>
+        <h4 class="step-title">Receive benefits</h4>
+        <p class="step-explanation">At providing the necessary information, you'll receive monthly benefits to help pay for food and</p>
       </div>
     </div>
   </div>

--- a/app/views/application/index.erb
+++ b/app/views/application/index.erb
@@ -1,8 +1,9 @@
 <form action="/application/basic_info" method="get" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
   <div class="homepage-message">
-    <h2 class="homepage-headline">You may be eligible for hundreds of dollars for food and groceries each year</h2>
+    <h2 class="homepage-headline">Receive extra money for food and groceries every month</h2>
+    <p class="page-context">Your family could qualify for between $100 and $3,000 in assistance annually.</p>
     <input class="btn next-step" type="submit" value="Start your application" autofocus="autofocus">
-    <h3 class="homepage-subheader">Apply online in 10 minutes</h3>
+    <h3 class="homepage-subheader">Get started in under 10 minutes</h3>
   </div>
   <div class="row steps-to-enroll" style="margin-top: 0; padding-top: 0;">
     <div class="col-md-4">
@@ -23,7 +24,7 @@
       <div class="step-to-enroll">
         <div class="circle step-to-enroll-icon">3</div>
         <h4 class="step-title">Receive benefits</h4>
-        <p class="step-explanation">At providing the necessary information, you'll receive monthly benefits to help pay for food and</p>
+        <p class="step-explanation">At providing the necessary information, you'll receive monthly benefits to help pay for food and groceries.</p>
       </div>
     </div>
   </div>

--- a/app/views/application/index.erb
+++ b/app/views/application/index.erb
@@ -2,7 +2,7 @@
   <div class="homepage-message">
     <h2 class="homepage-headline">Receive extra money for food and groceries every month</h2>
     <p class="page-context">Your family could qualify for between $100 and $3,000 in assistance annually.</p>
-    <input class="btn next-step" type="submit" value="Start your application" autofocus="autofocus">
+    <input class="btn next-step start-btn" type="submit" value="Start your application" autofocus="autofocus">
     <h3 class="homepage-subheader">Get started in under 10 minutes</h3>
   </div>
   <div class="row steps-to-enroll" style="margin-top: 0; padding-top: 0;">
@@ -31,6 +31,7 @@
 </form>
 <style>
   .masthead { text-align: center }
+  .footer { text-align: center;}
 </style>
 <script>
   $('.btn').button()

--- a/app/views/application/index.erb
+++ b/app/views/application/index.erb
@@ -1,6 +1,6 @@
 <form action="/application/basic_info" method="get" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
   <div class="homepage-message">
-    <h2 class="homepage-headline">You may be eligible for hundreds of dollars in food assistance.</h2>
+    <h2 class="homepage-headline">You may be eligible for hundreds of dollars for food and groceries</h2>
     <input class="btn next-step" type="submit" value="Start your application" autofocus="autofocus">
     <h3 class="homepage-subheader">Apply online in 10 minutes</h3>
   </div>

--- a/app/views/application/interview.erb
+++ b/app/views/application/interview.erb
@@ -1,7 +1,6 @@
 <form name="interview" action="/application/interview" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
-  <h3 class="page-header">When do you prefer your interview?</h3>
-  <p class="page-context">To enroll in CalFresh, you'll need to be interviewed. During the interview, a Human Services Agency staff will ask you personal questions about your income and expenses.</p>
-  <p class="page-context">When would you prefer to be contacted to have your interview? Staff will do their best to contact you during the specified times and days.</p>
+  <h3 class="page-header">When should the HSA call you to review your application?</h3>
+  <p class="page-context">To enroll in CalFresh, you'll need to speak with HSA staff about your application. During the interview, staff will ask you personal questions about your income and expenses. staff will do their best to contact you at the phone number you provided, during the days and times you choose below.</p>
   <div class="form-group">
     <div class="times-of-day middle">
       <div class="checkbox time-of-day">

--- a/app/views/application/interview.erb
+++ b/app/views/application/interview.erb
@@ -52,6 +52,8 @@
     </div>
   </div>
   <div class="page-footer">
+    <div class="page-footer-content col-md-4 col-md-offset-8">
       <input class="btn next-step" type="submit" value="Next Step">
+    </div>
   </div>
 </form>

--- a/app/views/application/interview.erb
+++ b/app/views/application/interview.erb
@@ -1,6 +1,6 @@
 <form name="interview" action="/application/interview" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
   <h3 class="page-header">When should the HSA call you to review your application?</h3>
-  <p class="page-context">To enroll in CalFresh, you'll need to speak with HSA staff about your application. During the interview, staff will ask you personal questions about your income and expenses. staff will do their best to contact you at the phone number you provided, during the days and times you choose below.</p>
+  <p class="page-context">Before you are approved for CalFresh, you'll need to speak with HSA staff. During the interview, they will review your application ask you for details about your income and expenses. The call usually takes about 15 minutes. Staff will do their best to contact you at the phone number you provided, during the days and times you choose below.</p>
   <div class="form-group">
     <div class="times-of-day middle">
       <div class="checkbox time-of-day">

--- a/app/views/application/interview.erb
+++ b/app/views/application/interview.erb
@@ -1,6 +1,6 @@
 <form name="interview" action="/application/interview" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
   <h3 class="page-header">When should the HSA call you to review your application?</h3>
-  <p class="page-context">Before you are approved for CalFresh, you'll need to speak with HSA staff. During the interview, they will review your application ask you for details about your income and expenses. The call usually takes about 15 minutes. Staff will do their best to contact you at the phone number you provided, during the days and times you choose below.</p>
+  <p class="page-context">Before you are approved for CalFresh, you'll need to speak with HSA staff. During the interview, they will review your application and ask for details about your income and expenses. The call usually takes about 15 minutes. Staff will do their best to contact you at the phone number you provided, during the days and times you choose below.</p>
   <div class="form-group">
     <div class="times-of-day middle">
       <div class="checkbox time-of-day">

--- a/app/views/application/review_and_submit.erb
+++ b/app/views/application/review_and_submit.erb
@@ -17,8 +17,8 @@
   </script>
 
 <form id="review_and_submit" name="review_and_submit" action="/application/review_and_submit" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1" data-parsley-validate>
-  <h2 class="page-header">Confirm and submit</h2>
-  <p class="page-context"><b>Last page! Signing your name below means you have told the truth on this application and that you want to apply for CalFresh.</b></p>
+  <h2 class="page-header">Review and submit</h2>
+  <p class="page-context"><b>Almost done! Read and agree to the statements below. Signing your name means you have told the truth on this application and that you want to submit an application for CalFresh.</b></p>
   <br>
   <p class="page-context">I understand that by signing this application under penalty of perjury (making false statements), that:
     <ul class="list">

--- a/app/views/application/sex_and_ssn.erb
+++ b/app/views/application/sex_and_ssn.erb
@@ -1,6 +1,6 @@
 <form name="sex_and_ssn" action="/application/sex_and_ssn" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
     <h2 class="page-header">Personal information</h2>
-    <p class="page-context">This information is required to uniquely identify you in our system.</p>
+    <p class="page-context">To deliver your benefits, HSA will need to be able to select you from among millions of other Californians. Your date of birth and social security number are critical to that task.</p>
 	<div class="form-group">
     <label for="date_of_birth" class="form-label">Your date of birth</label>
     <input type="text" class="form-control" name="date_of_birth" id="date_of_birth" placeholder="MM/DD/YY" required required data-parsley-required-message="Please provide your date of birth in the format described" data-parsley-pattern="^(?:(?:(?:0?[13578]|1[02])(\/|-|\.)31)\1|(?:(?:0?[1,3-9]|1[0-2])(\/|-|\.)(?:29|30)\2))(?:(?:1[6-9]|[2-9]\d)?\d{2})$|^(?:0?2(\/|-|\.)29\3(?:(?:(?:1[6-9]|[2-9]\d)?(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00))))$|^(?:(?:0?[1-9])|(?:1[0-2]))(\/|-|\.)(?:0?[1-9]|1\d|2[0-8])\4(?:(?:1[6-9]|[2-9]\d)?\d{2})$">

--- a/app/views/application/sex_and_ssn.erb
+++ b/app/views/application/sex_and_ssn.erb
@@ -3,11 +3,11 @@
     <p class="page-context">To deliver your benefits, HSA will need to be able to select you from among millions of other Californians. Your date of birth and social security number are critical to that task.</p>
 	<div class="form-group">
     <label for="date_of_birth" class="form-label">Your date of birth</label>
-    <input type="text" class="form-control" name="date_of_birth" id="date_of_birth" placeholder="MM/DD/YY" required required data-parsley-required-message="We need you to provide your date of birth to move forward!" data-parsley-pattern="^(?:(?:(?:0?[13578]|1[02])(\/|-|\.)31)\1|(?:(?:0?[1,3-9]|1[0-2])(\/|-|\.)(?:29|30)\2))(?:(?:1[6-9]|[2-9]\d)?\d{2})$|^(?:0?2(\/|-|\.)29\3(?:(?:(?:1[6-9]|[2-9]\d)?(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00))))$|^(?:(?:0?[1-9])|(?:1[0-2]))(\/|-|\.)(?:0?[1-9]|1\d|2[0-8])\4(?:(?:1[6-9]|[2-9]\d)?\d{2})$">
+    <input type="text" class="form-control" name="date_of_birth" id="date_of_birth" placeholder="MM/DD/YY" required required data-parsley-required-message="We need you to provide your date of birth to move forward! Note the format required." data-parsley-pattern="^(?:(?:(?:0?[13578]|1[02])(\/|-|\.)31)\1|(?:(?:0?[1,3-9]|1[0-2])(\/|-|\.)(?:29|30)\2))(?:(?:1[6-9]|[2-9]\d)?\d{2})$|^(?:0?2(\/|-|\.)29\3(?:(?:(?:1[6-9]|[2-9]\d)?(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00))))$|^(?:(?:0?[1-9])|(?:1[0-2]))(\/|-|\.)(?:0?[1-9]|1\d|2[0-8])\4(?:(?:1[6-9]|[2-9]\d)?\d{2})$" autofocus="autofocus">
   </div>
   <div class="form-group">
 		<label id="ssn" class="form-label">Social security number</label>
-		<input type="tel" class="form-control" name="ssn" id="ssn" autofocus="autofocus">
+		<input type="tel" class="form-control" name="ssn" id="ssn">
 	</div>
   <div class="form-group" data-toggle="buttons">
     <label class="form-label">Choose a sex</label>

--- a/app/views/application/sex_and_ssn.erb
+++ b/app/views/application/sex_and_ssn.erb
@@ -2,22 +2,26 @@
     <h2 class="page-header">Personal information</h2>
     <p class="page-context">This information is required to uniquely identify you in our system.</p>
 	<div class="form-group">
-		<label id="ssn" class="form-label">Social Security Number</label>
+    <label for="date_of_birth" class="form-label">Your date of birth</label>
+    <input type="text" class="form-control" name="date_of_birth" id="date_of_birth" placeholder="MM/DD/YY" required required data-parsley-required-message="Please provide your date of birth in the format described" data-parsley-pattern="^(?:(?:(?:0?[13578]|1[02])(\/|-|\.)31)\1|(?:(?:0?[1,3-9]|1[0-2])(\/|-|\.)(?:29|30)\2))(?:(?:1[6-9]|[2-9]\d)?\d{2})$|^(?:0?2(\/|-|\.)29\3(?:(?:(?:1[6-9]|[2-9]\d)?(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00))))$|^(?:(?:0?[1-9])|(?:1[0-2]))(\/|-|\.)(?:0?[1-9]|1\d|2[0-8])\4(?:(?:1[6-9]|[2-9]\d)?\d{2})$">
+  </div>
+  <div class="form-group">
+		<label id="ssn" class="form-label">Social security number</label>
 		<input type="tel" class="form-control" name="ssn" id="ssn" autofocus="autofocus">
 	</div>
   <div class="form-group" data-toggle="buttons">
     <label class="form-label">Choose a sex</label>
-    <div class="col-lg-4 form-button-col">
+    <div class="col-md-4 form-button-col">
       <button class="btn form-button form-control" data-toggle="button">
         <input type="radio" name="Female" id="female">Female
       </button>
     </div>
-    <div class="col-lg-4 form-button-col">
+    <div class="col-md-4 form-button-col">
       <button class="btn form-button form-control" data-toggle="button">
         <input type="radio" name="Male" id="male">Male
       </button>
     </div>
-    <div class="col-lg-4 form-button-col">
+    <div class="col-md-4 form-button-col">
       <button class="btn form-button form-control" data-toggle="button">
         <!-- It smells to me that name and id are not equivalent - AJW -->
         <input type="radio" name="options" name="NoAnswer" id="no-answer">No answer

--- a/app/views/application/sex_and_ssn.erb
+++ b/app/views/application/sex_and_ssn.erb
@@ -3,7 +3,7 @@
     <p class="page-context">To deliver your benefits, HSA will need to be able to select you from among millions of other Californians. Your date of birth and social security number are critical to that task.</p>
 	<div class="form-group">
     <label for="date_of_birth" class="form-label">Your date of birth</label>
-    <input type="text" class="form-control" name="date_of_birth" id="date_of_birth" placeholder="MM/DD/YY" required required data-parsley-required-message="Please provide your date of birth in the format described" data-parsley-pattern="^(?:(?:(?:0?[13578]|1[02])(\/|-|\.)31)\1|(?:(?:0?[1,3-9]|1[0-2])(\/|-|\.)(?:29|30)\2))(?:(?:1[6-9]|[2-9]\d)?\d{2})$|^(?:0?2(\/|-|\.)29\3(?:(?:(?:1[6-9]|[2-9]\d)?(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00))))$|^(?:(?:0?[1-9])|(?:1[0-2]))(\/|-|\.)(?:0?[1-9]|1\d|2[0-8])\4(?:(?:1[6-9]|[2-9]\d)?\d{2})$">
+    <input type="text" class="form-control" name="date_of_birth" id="date_of_birth" placeholder="MM/DD/YY" required required data-parsley-required-message="We need you to provide your date of birth to move forward!" data-parsley-pattern="^(?:(?:(?:0?[13578]|1[02])(\/|-|\.)31)\1|(?:(?:0?[1,3-9]|1[0-2])(\/|-|\.)(?:29|30)\2))(?:(?:1[6-9]|[2-9]\d)?\d{2})$|^(?:0?2(\/|-|\.)29\3(?:(?:(?:1[6-9]|[2-9]\d)?(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00))))$|^(?:(?:0?[1-9])|(?:1[0-2]))(\/|-|\.)(?:0?[1-9]|1\d|2[0-8])\4(?:(?:1[6-9]|[2-9]\d)?\d{2})$">
   </div>
   <div class="form-group">
 		<label id="ssn" class="form-label">Social security number</label>

--- a/app/views/application/sex_and_ssn.erb
+++ b/app/views/application/sex_and_ssn.erb
@@ -1,4 +1,4 @@
-<form name="sex_and_ssn" action="/application/sex_and_ssn" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
+<form name="sex_and_ssn" action="/application/sex_and_ssn" method="post" class="form row col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
     <h2 class="page-header">Personal information</h2>
     <p class="page-context">To deliver your benefits, HSA will need to be able to select you from among millions of other Californians. Your date of birth and social security number are critical to that task.</p>
 	<div class="form-group">
@@ -9,7 +9,7 @@
 		<label id="ssn" class="form-label">Social security number</label>
 		<input type="tel" class="form-control" name="ssn" id="ssn">
 	</div>
-  <div class="form-group" data-toggle="buttons">
+  <div class="row btn-form-group form-group" data-toggle="buttons">
     <label class="form-label">Choose a sex</label>
     <div class="col-md-4 form-button-col">
       <button class="btn form-button form-control" data-toggle="button">
@@ -29,9 +29,9 @@
     </div>
   </div>
   <div class="page-footer">
-  	<div class="footer-content">
-        <input class="btn next-step" type="submit" value="Next Step">
-  	</div>
+    <div class="page-footer-content col-md-4 col-md-offset-8">
+      <input class="btn next-step" type="submit" value="Next Step">
+    </div>
   </div>
 </form>
 <script>

--- a/app/views/application/sex_and_ssn.erb
+++ b/app/views/application/sex_and_ssn.erb
@@ -1,6 +1,6 @@
 <form name="sex_and_ssn" action="/application/sex_and_ssn" method="post" class="form row col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
     <h2 class="page-header">Personal information</h2>
-    <p class="page-context">To deliver your benefits, HSA will need to be able to select you from among millions of other Californians. Your date of birth and social security number are critical to that task.</p>
+    <p class="page-context">Your date of birth and social security number are key parts of your CalFresh application. They help HSA ensure your benefits get delivered to you, and no one else.</p>
 	<div class="form-group">
     <label for="date_of_birth" class="form-label">Your date of birth</label>
     <input type="text" class="form-control" name="date_of_birth" id="date_of_birth" placeholder="MM/DD/YY" required required data-parsley-required-message="We need you to provide your date of birth to move forward! Note the format required." data-parsley-pattern="^(?:(?:(?:0?[13578]|1[02])(\/|-|\.)31)\1|(?:(?:0?[1,3-9]|1[0-2])(\/|-|\.)(?:29|30)\2))(?:(?:1[6-9]|[2-9]\d)?\d{2})$|^(?:0?2(\/|-|\.)29\3(?:(?:(?:1[6-9]|[2-9]\d)?(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00))))$|^(?:(?:0?[1-9])|(?:1[0-2]))(\/|-|\.)(?:0?[1-9]|1\d|2[0-8])\4(?:(?:1[6-9]|[2-9]\d)?\d{2})$" autofocus="autofocus">

--- a/app/views/application/sex_and_ssn.erb
+++ b/app/views/application/sex_and_ssn.erb
@@ -3,7 +3,7 @@
     <p class="page-context">Your date of birth and social security number are key parts of your CalFresh application. They help HSA ensure your benefits get delivered to you, and no one else.</p>
 	<div class="form-group">
     <label for="date_of_birth" class="form-label">Your date of birth</label>
-    <input type="text" class="form-control" name="date_of_birth" id="date_of_birth" placeholder="MM/DD/YY" required required data-parsley-required-message="We need you to provide your date of birth to move forward! Note the format required." data-parsley-pattern="^(?:(?:(?:0?[13578]|1[02])(\/|-|\.)31)\1|(?:(?:0?[1,3-9]|1[0-2])(\/|-|\.)(?:29|30)\2))(?:(?:1[6-9]|[2-9]\d)?\d{2})$|^(?:0?2(\/|-|\.)29\3(?:(?:(?:1[6-9]|[2-9]\d)?(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00))))$|^(?:(?:0?[1-9])|(?:1[0-2]))(\/|-|\.)(?:0?[1-9]|1\d|2[0-8])\4(?:(?:1[6-9]|[2-9]\d)?\d{2})$" autofocus="autofocus">
+    <input type="text" class="form-control" name="date_of_birth" id="date_of_birth" placeholder="MM/DD/YY" required required data-parsley-required-message="Please provide your date of birth in the format shown above." data-parsley-pattern="^(?:(?:(?:0?[13578]|1[02])(\/|-|\.)31)\1|(?:(?:0?[1,3-9]|1[0-2])(\/|-|\.)(?:29|30)\2))(?:(?:1[6-9]|[2-9]\d)?\d{2})$|^(?:0?2(\/|-|\.)29\3(?:(?:(?:1[6-9]|[2-9]\d)?(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00))))$|^(?:(?:0?[1-9])|(?:1[0-2]))(\/|-|\.)(?:0?[1-9]|1\d|2[0-8])\4(?:(?:1[6-9]|[2-9]\d)?\d{2})$" autofocus="autofocus">
   </div>
   <div class="form-group">
 		<label id="ssn" class="form-label">Social security number</label>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,15 +24,5 @@
   <div class="main">
     <%= yield %>
   </div>
-  <div class="footer">
-    <div class="col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
-      <div class="row footer-content">
-          <p><b>Need Assistance?</b></p>
-          <p>Call (510) 206-8727</p>
-          <p>Email <a href="mailto:health-lab@codeforamerica.org">health-lab@codeforamerica.org</a></p>
-          <p>CleanAssist.org is a <b><a href="http://codeforamerica.org">Code for America</a></b> project</p>
-      </div>
-    </div>
-  </div>
 </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,7 @@
 <body>
   <div class="masthead">
     <div class="col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
-      <p class="brand">Apply for CalFresh in San Francisco, CA</p>
+      <p class="brand">Apply for CalFresh in San Francisco</p>
     </div>
   </div>
   <div class="main">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,10 +26,11 @@
   </div>
   <div class="footer">
     <div class="col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
-      <div class="footer-content">
-        <p>Code for America</p>
-        <p>155 9th Street</p>
-        <p>San Francisco, CA 94103</p>
+      <div class="row footer-content">
+          <p><b>Need Assistance?</b></p>
+          <p>Call (510) 206-8727</p>
+          <p>Email <a href="mailto:health-lab@codeforamerica.org">health-lab@codeforamerica.org</a></p>
+          <p>CleanAssist.org is a <b><a href="http://codeforamerica.org">Code for America</a></b> project</p>
       </div>
     </div>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,5 +24,11 @@
   <div class="main">
     <%= yield %>
   </div>
+  <div class="footer">
+    <div class="col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
+      <p class="footer-content"><b>Need Help? Get in touch.</b></p>
+      <p class="footer-content">Call (510) 206-8727</p>
+      <p class="footer-content">Email health-lab@codeforamerica.org</p>
+  </div>
 </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,13 +16,22 @@
   <script>try{Typekit.load();}catch(e){}</script>
 </head>
 <body>
-  <div id="main">
-    <div class="masthead">
-      <div class="col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
-        <p class="brand">Apply for CalFresh in San Francisco, CA</p>
+  <div class="masthead">
+    <div class="col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
+      <p class="brand">Apply for CalFresh in San Francisco, CA</p>
+    </div>
+  </div>
+  <div class="main">
+    <%= yield %>
+  </div>
+  <div class="footer">
+    <div class="col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
+      <div class="footer-content">
+        <p>Code for America</p>
+        <p>155 9th Street</p>
+        <p>San Francisco, CA 94103</p>
       </div>
     </div>
-    <%= yield %>
   </div>
 </body>
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
   get 'application/household_question' => 'application#household_question'
   get 'application/additional_household_member' => 'application#additional_household_member'
   post 'application/additional_household_member' => 'application#additional_household_member_submit'
+  get 'application/additional_household_question' => 'application#additional_household_question'
   get 'application/review_and_submit' => 'application#review_and_submit'
   post 'application/review_and_submit' => 'application#review_and_submit_submit'
   get 'application/confirmation' => 'application#confirmation'

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -27,13 +27,18 @@ RSpec.describe ApplicationController, :type => :controller do
 
   describe 'POST /application/basic_info' do
     before do
-      @input_hash = { name: 'dave', date_of_birth: '06/01/75' }
+      @input_hash = {
+        name: 'dave',
+        home_address: '1234 Fake St',
+        home_zip_code: '94113',
+        home_city: 'San Francisco',
+        home_state: 'CA',
+      }
       post :basic_info_submit, @input_hash
     end
 
     it 'saves basic_info to the session' do
       expect(@request.session[:name]).to eq('dave')
-      expect(@request.session[:date_of_birth]).to eq('06/01/75')
     end
 
     it 'redirects to contact_info' do
@@ -54,10 +59,6 @@ RSpec.describe ApplicationController, :type => :controller do
       @input_hash = {
         home_phone_number: '1112223333',
         email: 'joe@example.com',
-        home_address: '1234 Fake St',
-        home_zip_code: '94113',
-        home_city: 'San Francisco',
-        home_state: 'CA',
         primary_language: "English"
       }
       post :contact_info_submit, @input_hash
@@ -86,6 +87,7 @@ RSpec.describe ApplicationController, :type => :controller do
     context 'with ssn and sex selected' do
       before do
         @input_hash = {
+          date_of_birth: '06/01/75',
           "ssn" => '1112223333',
           "Male" => 'on'
         }
@@ -94,6 +96,7 @@ RSpec.describe ApplicationController, :type => :controller do
 
       it 'saves contact info into the session' do
         desired_hash = {
+          date_of_birth: '06/01/75',
           ssn: '1112223333',
           sex: 'M'
         }
@@ -102,9 +105,9 @@ RSpec.describe ApplicationController, :type => :controller do
         end
       end
 
-      it 'redirects to medi-cal page' do
+      it 'redirects to household question page' do
         expect(@response).to be_redirect
-        expect(@response.location).to include('/application/interview')
+        expect(@response.location).to include('/application/household_question')
       end
     end
 
@@ -126,9 +129,9 @@ RSpec.describe ApplicationController, :type => :controller do
         end
       end
 
-      it 'redirects to the interview page' do
+      it 'redirects to the household question page' do
         expect(@response).to be_redirect
-        expect(@response.location).to include('/application/interview')
+        expect(@response.location).to include('/application/household_question')
       end
     end
   end
@@ -160,9 +163,9 @@ RSpec.describe ApplicationController, :type => :controller do
         end
       end
 
-      it 'redirects to household_question page' do
+      it 'redirects to confirmation / review_and_submit page' do
         expect(@response).to be_redirect
-        expect(@response.location).to include('/application/household_question')
+        expect(@response.location).to include('/application/review_and_submit')
       end
     end
 
@@ -177,9 +180,9 @@ RSpec.describe ApplicationController, :type => :controller do
         expect(@request.session).to be_empty
       end
 
-      it 'redirects to household_question page' do
+      it 'redirects to confirmation / review_and_submit page page' do
         expect(@response).to be_redirect
-        expect(@response.location).to include('/application/household_question')
+        expect(@response.location).to include('/application/review_and_submit')
       end
     end
   end
@@ -224,10 +227,11 @@ RSpec.describe ApplicationController, :type => :controller do
         end
       end
 
-      # To be changed to next_addl_household_member in future
-      it 'redirects back to household_question' do
+      # To be changed to next_addl_household_member in future - DONE
+      # We should add a new test for routing additional_hh_q => interview, hh info
+      it 'redirects to additional_household_question' do
         expect(@response).to be_redirect
-        expect(@response.location).to include('/application/household_question')
+        expect(@response.location).to include('/application/additional_household_question')
       end
     end
 

--- a/spec/features/all_features_spec.rb
+++ b/spec/features/all_features_spec.rb
@@ -13,11 +13,9 @@ feature 'User leaves required fields empty', :js => true do
     visit '/application/basic_info?'
       expect(page.current_path).to eq('/application/basic_info')
       fill_in('name', with: '')
-      fill_in('date_of_birth', with: '')
       click_on('Next Step')
       expect(page.current_path).to eq('/application/basic_info')
-      expect(page).to have_content('Name is required to apply')
-      expect(page).to have_content('Please provide your date of birth in the format described')
+      expect(page).to have_content('Provide your full name to get started!')
   end
 end
 
@@ -25,24 +23,19 @@ feature 'User goes through full application (up to review and submit)' do
   scenario 'with basic interactions' do
     visit '/application/basic_info?'
       fill_in 'name', with: 'Hot Snakes'
-      fill_in 'date_of_birth', with: "01/01/2000"
+      fill_in 'home_address', with: "2015 Market Street"
+      fill_in 'home_zip_code', with: "94122"
       click_button 'Next Step'
       expect(page.current_path).to eq('/application/contact_info')
       fill_in 'home_phone_number', with: "5555555555"
       fill_in 'email', with: "hotsnakes@gmail.com"
-      fill_in 'home_address', with: "2015 Market Street"
-      fill_in 'home_zip_code', with: "94122"
       click_on('Next Step')
       expect(page.current_path).to eq('/application/sex_and_ssn')
+      fill_in 'date_of_birth', with: "01/01/2000"
       fill_in 'ssn', with: "000000000"
       choose('no-answer')
       click_on('Next Step')
-      expect(page.current_path).to eq('/application/interview')
-      check('monday')
-      check('friday')
-      check('mid-morning')
-      check('late-afternoon')
-      click_on('Next Step')
+
       expect(page.current_path).to eq('/application/household_question')
       click_link('Yes')
       expect(page.current_path).to eq('/application/additional_household_member')
@@ -51,9 +44,14 @@ feature 'User goes through full application (up to review and submit)' do
       fill_in 'their_ssn', with: "000000000"
       choose('male')
       click_on('Next Step')
-      expect(page).to have_content("Do you buy and cook food with anyone?")
-      expect(page.current_path).to eq('/application/household_question')
+      expect(page.current_path).to eq('/application/additional_household_question')
       click_link('No')
+      expect(page.current_path).to eq('/application/interview')
+      check('monday')
+      check('friday')
+      check('mid-morning')
+      check('late-afternoon')
+      click_on('Next Step')
       expect(page.current_path).to eq('/application/review_and_submit')
   end
 end


### PR DESCRIPTION
This will close #343 the deceptively tidy issue dubbed "Copy Audit", along with #342 
- Adds a new view `additional_household_question.erb` and corresponding routes. This view makes the process of asking for information about an arbitrary number of individual family and household members much more clear.
- Updates the user flow to push interview scheduling after the documentation of household members.
- Moves the `date_of_birth` form from `basic_info.erb` to `sex_and_ssn.erb`, which seems much more appropriate. 
- Moves the street address and ZIP code information from `contact_info.erb` up to `basic_info.erb`. Along with the DOB change, this brings the flow far more in line with the sequencing of questions we've observed with assisters.
- More consistent page headers across the flow.
- Better (but not good enough) copy writing across the app. We just needed to ship these improvements. We'll continue to tweak copy.
- Updated parsley error message copy, but not their design. I'd love to talk to @daguar about modifying the parsley styles soon—it's not totally obvious to me right now.
- Added a v1 footer that includes Jake's cell and the health-lab email address, so that assisters can get assistance from any screen.
- Updated the form styles a bit more.
- Updated the messaging on the homepage.