### PR TITLE
Save case data to Postgres, closes #321

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ gem 'airbrake'
 
 gem 'prawn'
 
+gem 'chronic'
+
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,7 @@ GEM
     capybara-webkit (1.4.1)
       capybara (>= 2.3.0, < 2.5.0)
       json
+    chronic (0.10.2)
     climate_control (0.0.3)
       activesupport (>= 3.0)
     coderay (1.1.0)
@@ -211,6 +212,7 @@ DEPENDENCIES
   byebug
   capybara
   capybara-webkit
+  chronic
   climate_control
   coffee-rails (~> 4.1.0)
   jbuilder (~> 2.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,4 @@
- class ApplicationController < ActionController::Base
+class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   #protect_from_forgery with: :exception
@@ -165,7 +165,6 @@
     input_for_writer[:language_preference_reading] = session[:primary_language]
     input_for_writer[:language_preference_writing] = session[:primary_language]
     @application = writer.fill_out_form(input_for_writer)
-    #if @application.has_pngs?
       client = SendGrid::Client.new(api_user: ENV['SENDGRID_USERNAME'], api_key: ENV['SENDGRID_PASSWORD'])
       mail = SendGrid::Mail.new(
         to: ENV['EMAIL_ADDRESS_TO_SEND_TO'],
@@ -197,14 +196,9 @@ EOF
       mail.add_attachment(zip_file_path)
       @email_result_application = client.send(mail)
       puts @email_result_application
-      #erb :after_fax
-    #end
-=begin
-    else
-      puts "No PNGs! WTF!?!"
-      #redirect to('/')
-    end
-=end
+      data_to_save = Case.process_data_for_storage(session.to_hash)
+      c = Case.new(data_to_save)
+      c.save
     redirect_to '/application/document_instructions'
   end
 

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -1,0 +1,24 @@
+class Case < ActiveRecord::Base
+
+  def self.process_data_for_storage(input_hash)
+    data_to_save = input_hash.select do |k,v|
+      %w(name date_of_birth home_phone_number email home_address home_zip_code home_city home_state primary_language sex additional_household_members contact_by_email contact_by_text_message contact_by_phone_call interview_early_morning interview_mid_morning interview_afternoon interview_late_afternoon interview_monday interview_tuesday interview_wednesday interview_thursday interview_friday).include?(k)
+    end
+    data_to_save['date_of_birth'] = Chronic.parse(data_to_save['date_of_birth'])
+    if data_to_save['additional_household_members']
+      household_members_data_without_ssn = data_to_save['additional_household_members'].map do |hhm|
+        hhm.select do |k,v|
+          k.to_s != 'ssn'
+        end
+      end
+      data_to_save['additional_household_members'] = household_members_data_without_ssn
+    end
+    data_to_save.each do |k,v|
+      if k.include?('interview') && data_to_save[k] == 'Yes'
+        data_to_save[k] = true
+      end
+    end
+    data_to_save
+  end
+
+end

--- a/db/migrate/20150302231943_create_cases.rb
+++ b/db/migrate/20150302231943_create_cases.rb
@@ -1,0 +1,22 @@
+class CreateCases < ActiveRecord::Migration
+  def change
+    create_table :cases do |t|
+      t.string :name
+      t.date :date_of_birth
+      t.string :email
+      t.string :home_phone_number
+      t.string :home_address
+      t.string :home_zip_code
+      t.string :home_city
+      t.string :home_state
+      t.string :primary_language
+      t.string :sex
+      t.json :additional_household_members
+      t.boolean :contact_by_email
+      t.boolean :contact_by_text_message
+      t.boolean :contact_by_phone_call
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20150303004215_add_interview_times_to_case.rb
+++ b/db/migrate/20150303004215_add_interview_times_to_case.rb
@@ -1,0 +1,13 @@
+class AddInterviewTimesToCase < ActiveRecord::Migration
+  def change
+    add_column :cases, :interview_early_morning, :boolean
+    add_column :cases, :interview_mid_morning, :boolean
+    add_column :cases, :interview_afternoon, :boolean
+    add_column :cases, :interview_late_afternoon, :boolean
+    add_column :cases, :interview_monday, :boolean
+    add_column :cases, :interview_tuesday, :boolean
+    add_column :cases, :interview_wednesday, :boolean
+    add_column :cases, :interview_thursday, :boolean
+    add_column :cases, :interview_friday, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,9 +11,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 20150303004215) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "cases", force: :cascade do |t|
+    t.string   "name"
+    t.date     "date_of_birth"
+    t.string   "email"
+    t.string   "home_phone_number"
+    t.string   "home_address"
+    t.string   "home_zip_code"
+    t.string   "home_city"
+    t.string   "home_state"
+    t.string   "primary_language"
+    t.string   "sex"
+    t.json     "additional_household_members"
+    t.boolean  "contact_by_email"
+    t.boolean  "contact_by_text_message"
+    t.boolean  "contact_by_phone_call"
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
+    t.boolean  "interview_early_morning"
+    t.boolean  "interview_mid_morning"
+    t.boolean  "interview_afternoon"
+    t.boolean  "interview_late_afternoon"
+    t.boolean  "interview_monday"
+    t.boolean  "interview_tuesday"
+    t.boolean  "interview_wednesday"
+    t.boolean  "interview_thursday"
+    t.boolean  "interview_friday"
+  end
 
 end

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe Case, :type => :model do
+end


### PR DESCRIPTION
- Saves all case data except SSNs to Postgres in the `Case` model
- Currently, all data fields are of type `string` except for:
 - date_of_birth (date)
 - additional_household_members (json of all the hh member info, since we're unlikely to need to query against this)
