### PR TITLE
Printable confirmation page

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -179,7 +179,7 @@ body {
 
 }
 
-.homepage-subheader {
+.page-subheader {
 	@include subheader-type;
 	line-height: 1.4em;
 	font-weight: 700;
@@ -520,6 +520,9 @@ input.disabled {
 	min-height: 200px;
 }
 
+.print-visible {
+	display: none;
+}
 
 /* M E D I A    Q U E R I E S */
 
@@ -555,6 +558,42 @@ input.disabled {
 /* Smartphones (portrait) ----------- */
 @media only screen and (max-width : 320px) {
 /* Styles */
+}
+
+/* P R I N T    S T Y L E S */
+/* For now, these are used exclusively for the confirmation / complete page. */
+
+@media print {
+  body {
+    width: 100%;
+  }
+  .masthead {
+  	display: none;
+  }
+  .footer {
+  	display: none;
+  }
+  .print-hidden {
+  	display: none;
+  }
+  .print-visible {
+  	display: inline-block;
+  	.page-subheader {
+  		font-size: 21px;
+  	}
+  	.page-header {
+  		font-size: 32px;
+  	}
+  	.form-label {
+  		font-size: 16px;
+  	}
+  	.list {
+  		font-size: 16px;
+  	}
+  	.page-context {
+  		font-size: 16px;
+  	}
+  }
 }
 
  /* B O O T S R A P   H A C K S */

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -199,7 +199,7 @@ EOF
       data_to_save = Case.process_data_for_storage(session.to_hash)
       c = Case.new(data_to_save)
       c.save
-    redirect_to '/application/document_instructions'
+    redirect_to '/application/confirmation'
   end
 
   def document_instructions

--- a/app/views/application/confirmation.erb
+++ b/app/views/application/confirmation.erb
@@ -1,31 +1,50 @@
 <form name="confirmation" action="/application/confirmation" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
-	<h2 class="page-header">You're application has been submitted!</h2>
-	<p class="page-context">There are two more steps before it can be approved&mdash;sending verification documents in, and having your interview with Human Services Agency staff.</p>
-	<p class="page-context"><b>Already have documents on hand?</b></p>
-	<p class="page-context">If you have already gathered documents about your income, expenses and identification, please upload photos of them now.<p>
-	<div class="row form-group">
-		<div class="col-lg-6 form-button-col">
-			<p class="form-context">Yes, I have documents ready to send. Let's get started!</p>
-			<br>
-			<a href="/documents/<%= @user_token %>/0" class="btn form-button" autofocus="autofocus">Start uploading</a>
-		</div>
-		<div class="col-lg-6 form-button-col">
-			<p class="form-context">No, I'll need to gather my documents and submit another time.</p>
-			<br>
-			<a href="/complete" class="btn form-button">Call it a day</a>
-		</div>
-	</div>
-	<br>
-	<div class="form-group">
-		<p class="form-label">Not sure what kind of documents you need?</p>
-		<p class="page-context">Documents you'll need include those show your income, living expenses, and personal identification. Valid documents include:
+	<div class="print-hidden">
+		<h2 class="page-header">You submitted an application for CalFresh in San Francisco!</h2>
+		<div class="alert alert-info"><b>Print out this page</b> as a reciept. It will have today's date, next steps, and a place to write notes.</div>
+		<p class="page-subheader">What's next?</p>
+		<p class="page-context">You should receive a phone call from the San Francisco Human Services Agency soon&mdash;about 3 to 5 days.</p>
+		<br>
+		<p class="page-subheader">In the meantime</p>
+		<p class="page-context">Here's how you can prepare for your interview with HSA:</p>
 		<ul class="list">
-			<li class="list-item">Driver's licenses and passports</li>
-			<li class="list-item">Bank statements</li>
-			<li class="list-item">Lease agreements</li>
-			<li class="list-item">Utility bills</li>
-			<li class="list-item">Written and signed statements</li>
+			<li>Hold on to any verification documents you submitted with this application. It can be helpful to have them available when HSA calls.</li>
+			<li>If you think you need to provide documents beyond what you submitted today, try to collect them before your call with HSA. Documents you'll need include those show your income, living expenses, and personal identification. Valid documents include:</li>
+				<ul class="list">
+					<li>Driver's licenses and passports</li>
+					<li>Bank statements</li>
+					<li>Lease agreements</li>
+					<li>Utility bills</li>
+					<li>Government issued ID for each person you included in your application.</li>
+				</ul>
 		</ul>
-		<p class="page-context">You'll need to provide government ID for each person you cook and prepare food with, as well.</p>
+		<br>
+		<p class="page-subheader">Don't wait too long</p>
+		<p class="page-context">If you don't hear from HSA within a week, call (415) 558-1001 and say you need a phone interview for your CalFresh application.</p>
+	</div>
+	<div class="print-visible">
+		<br>
+		<p class="page-subheader">Success! Hold on to this reciept.</p>
+		<h2 class="page-header">You submitted an application for CalFresh in San Francisco.</h2>
+		<p class="page-subheader">What's next?</p>
+		<p class="page-context">You should receive a phone call from the San Francisco Human Services Agency soon&mdash;about 3 to 5 days.</p>
+		<p class="page-subheader">In the meantime</p>
+		<p class="page-context">Here's how you can prepare for your interview with HSA:</p>
+		<ul class="list">
+			<li>Hold on to any verification documents you submitted with this application. It can be helpful to have them available when HSA calls.</li>
+			<li>If you think you need to provide documents beyond what you submitted today, try to collect them before your call with HSA. Documents you'll need include those show your income, living expenses, and personal identification. Valid documents include:</li>
+				<ul class="list">
+					<li>Driver's licenses and passports</li>
+					<li>Bank statements</li>
+					<li>Lease agreements</li>
+					<li>Utility bills</li>
+					<li>Government issued ID for each person you included in your application.</li>
+				</ul>
+		</ul>
+		<p class="page-subheader">Don't wait too long</p>
+		<p class="page-context">If you don't hear from HSA within a week, call (415) 558-1001 and say you need a phone interview for your CalFresh application.</p>
+		<h2 class="page-header"></h2>
+		<p class="form-label">Assister or Personal Notes</p>
+		</div>
 	</div>
 </form>


### PR DESCRIPTION
Closes #355 

This is the first version of a printable `/confirmation` page. It's relatively spare to a) address space constraints, keeping it to one page, b) require no application specific data and  c) avoid over-prescribing how it should be used. Instead, it focuses on the clear, universal next steps that are known bottlenecks—the interview and the submission of verification documents. We offer a single phone number for the client to take action—HSA's. We include an unstructured "notes" section for assisters to add their own information.

It should also be noted that the `/confirmation.erb` view is not currently served in the application flow. However, this should be served immediately after signature, once we have document upload in flow before signature.