### PR TITLE
Info sharing update

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -341,6 +341,8 @@ body {
 	padding-right: 20px;
 }
 
+
+
 /* F O R M   B U T T O N  and B R A N C H   N A V  B T N S  */
 
 input[type="radio"] {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -126,7 +126,14 @@ class ApplicationController < ActionController::Base
   end
 
   def info_sharing_submit
-    [:contact_by_phone_call, :contact_by_text_message, :contact_by_email].each do |preference_name|
+    redirect_to '/application/follow_up'
+  end
+
+  def follow_up
+  end
+
+  def follow_up_submit
+    [:contact_by_phone_call, :contact_by_text_message, :contact_by_email, :contact_by_voicemail].each do |preference_name|
       if params[preference_name] == 'on'
         session[preference_name] = true
       else

--- a/app/views/application/follow_up.erb
+++ b/app/views/application/follow_up.erb
@@ -10,17 +10,17 @@
       </div>
       <div class="checkbox">
         <label class="page-context">
-          <input type="checkbox" name="contact_by_text_message" autofocus="autofocus"> Text Message
+          <input type="checkbox" name="contact_by_text_message"> Text Message
         </label>
       </div>
       <div class="checkbox">
         <label class="page-context">
-          <input type="checkbox" name="contact_by_email" autofocus="autofocus"> Email
+          <input type="checkbox" name="contact_by_email"> Email
         </label>
       </div>
       <div class="checkbox">
         <label class="page-context">
-          <input type="checkbox" name="contact_by_voicemail" autofocus="autofocus"> Voicemail
+          <input type="checkbox" name="contact_by_voicemail"> Voicemail
         </label>
       </div>
     </div>

--- a/app/views/application/follow_up.erb
+++ b/app/views/application/follow_up.erb
@@ -1,0 +1,33 @@
+<form id="follow_up" name="follow_up" action="/application/follow_up" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1" data-parsley-validate>
+  <h2 class="page-header">How should we follow up with you?</h2>
+  <p class="page-context">In our work to ensure your application is processed properly, we may need to get in touch. How would you prefer we contact you about your case status?</p>
+  <div class="form-group">
+    <div class="times-of-day middle">
+      <div class="checkbox">
+        <label class="page-context">
+          <input type="checkbox" name="contact_by_phone_call" autofocus="autofocus"> Phone Call
+        </label>
+      </div>
+      <div class="checkbox">
+        <label class="page-context">
+          <input type="checkbox" name="contact_by_text_message" autofocus="autofocus"> Text Message
+        </label>
+      </div>
+      <div class="checkbox">
+        <label class="page-context">
+          <input type="checkbox" name="contact_by_email" autofocus="autofocus"> Email
+        </label>
+      </div>
+      <div class="checkbox">
+        <label class="page-context">
+          <input type="checkbox" name="contact_by_voicemail" autofocus="autofocus"> Voicemail
+        </label>
+      </div>
+    </div>
+  </div>
+  <div class="page-footer">
+    <div class="page-footer-content col-md-4 col-md-offset-8">
+      <input class="btn next-step" name="confirmation" type="submit" value="Next Step">
+    </div>
+  </div>
+</form>

--- a/app/views/application/info_sharing.erb
+++ b/app/views/application/info_sharing.erb
@@ -1,38 +1,17 @@
 <form id="info_sharing" name="info_sharing" action="/application/info_sharing" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1" data-parsley-validate>
-  <h2 class="page-header">Caring for your case</h2>
-  <p class="page-context"><b>CleanAssist isn't just a way to apply online&mdash;it's also a way to ensure your application is processed correctly. Staff at Code for America will check in on your application, and let you know if there are any issues.</b></p>
+  <h2 class="page-header">Let us care for your case</h2>
+  <p class="page-context"><b>With your permission, we will check in on your application and let you know about any issues. We will <i>only</i> use your application information to to make sure your case is processed properly.</p>
+  </b></p>
   <div class="form-group">
-    <p class="page-context">To do that, we ask that you agree to release the information you've documented today to Code for America. We will <i>only</i> use your application information to to make sure your case is processed properly.</p>
     <p class="page-context">Specifically, we ask you to agree to release the following information to help us advocate on your behalf:
       <ul class="list">
-        <li class="list-item">Case number</li>
-        <li class="list-item">Current and past application status</li>
-        <li class="list-item">Dates and reasons for all changes to application status</li>
-        <li class="list-item">Reasons for cases judgements</li>
-        <li class="list-item">Description of all verification docuemnts</li>
+        <li class="list-item">Your case number</li>
+        <li class="list-item">Your current and past application status</li>
+        <li class="list-item">Changes to your application status</li>
+        <li class="list-item">The reasons for case approval or denial</li>
+        <li class="list-item">The content of all submitted documents</li>
       </ul>
     </p>
-  </div>
-  <div class="form-group">
-    <p class="form-label">How should we contact you if needed?</p>
-    <p class="form-context">In our work to ensure your application is processed properly, we may need to get in touch. How would you prefer we contact you about your case status?</p>
-    <div class="times-of-day middle">
-      <div class="checkbox time-of-day">
-        <label class="page-context">
-          <input type="checkbox" name="contact_by_phone_call" autofocus="autofocus"> Phone Call
-        </label>
-      </div>
-      <div class="checkbox time-of-day">
-        <label class="page-context">
-          <input type="checkbox" name="contact_by_text_message" autofocus="autofocus"> Text Message
-        </label>
-      </div>
-      <div class="checkbox time-of-day">
-        <label class="page-context">
-          <input type="checkbox" name="contact_by_email" autofocus="autofocus"> Email
-        </label>
-      </div>
-    </div>
   </div>
   <div class="page-footer">
     <div class="page-footer-content col-md-4 col-md-offset-8">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,8 @@ Rails.application.routes.draw do
   post 'application/interview' => 'application#interview_submit'
   get 'application/info_sharing' => 'application#info_sharing'
   post 'application/info_sharing' => 'application#info_sharing_submit'
+  get 'application/follow_up' => 'application#follow_up'
+  post 'application/follow_up' => 'application#follow_up_submit'
   get 'application/rights_and_regs' => 'application#rights_and_regs'
   post 'application/rights_and_regs' => 'application#rights_and_regs_submit'
   get 'application/review_and_submit' => 'application#review_and_submit'

--- a/lib/calfresh.rb
+++ b/lib/calfresh.rb
@@ -215,13 +215,6 @@ Code for America
 www.codeforamerica.org
 EOF
 )
-
-Leo O'Farrell
-CalFresh Program Director
-leo.o'farrell@sfgov.org
-
-EOF
-)
       pdf.render_file(params[:path_for_pdf])
     end
   end

--- a/lib/calfresh.rb
+++ b/lib/calfresh.rb
@@ -192,7 +192,7 @@ module Calfresh
       end
       pdf.move_down 10
       pdf.text(<<EOF
-I, #{name}, authorize you to release the following information regarding my CalFresh application or active case to Code for America:
+I, #{name}, authorize you to release the following information regarding my CalFresh application or active case to Code for America for :
 
 - Case number
 - Current and past application status
@@ -201,7 +201,7 @@ I, #{name}, authorize you to release the following information regarding my CalF
 - Reasons my case was pended or denied
 - Description of all verification documents that were submitted
 
-Code for America will use this information to make sure my case is processed properly.
+Code for America will use this information to make sure my case is processed properly. This release is valid for one year from the date of application submission.
 EOF
 )
       pdf.image(params[:signature_png_path], scale: 0.3)
@@ -213,6 +213,13 @@ Code for America
 155 9th Street, San Francisco 94103
 (415) 625-9633
 www.codeforamerica.org
+EOF
+)
+
+Leo O'Farrell
+CalFresh Program Director
+leo.o'farrell@sfgov.org
+
 EOF
 )
       pdf.render_file(params[:path_for_pdf])

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -283,10 +283,10 @@ RSpec.describe ApplicationController, :type => :controller do
 
   describe 'POST /application/follow_up' do
     context 'with all options selected' do
-      it 'stores all of the content method preference into session' do
-        all_options_selected_params_hash = { :contact_by_phone_call => 'on', :contact_by_text_message => 'on', :contact_by_email => 'on' }
-        post :info_sharing_submit, all_options_selected_params_hash
-        [:contact_by_phone_call, :contact_by_text_message, :contact_by_email].each do |preference_name|
+      it 'stores all of the contact method preference into session' do
+        all_options_selected_params_hash = { :contact_by_phone_call => 'on', :contact_by_text_message => 'on', :contact_by_email => 'on', :contact_by_voicemail => 'on', }
+        post :follow_up_submit, all_options_selected_params_hash
+        [:contact_by_phone_call, :contact_by_text_message, :contact_by_email, :contact_by_voicemail].each do |preference_name|
           expect(@request.session[preference_name]).to eq(true)
         end
       end
@@ -294,8 +294,8 @@ RSpec.describe ApplicationController, :type => :controller do
 
     context 'with no options selected' do
       it 'stores nothing in the session' do
-        post :info_sharing_submit, {}
-        [:contact_by_phone_call, :contact_by_text_message, :contact_by_email].each do |preference_name|
+        post :follow_up_submit, {}
+        [:contact_by_phone_call, :contact_by_text_message, :contact_by_email, :contact_by_voicemail].each do |preference_name|
           expect(@request.session[preference_name]).to eq(false)
         end
       end
@@ -304,7 +304,7 @@ RSpec.describe ApplicationController, :type => :controller do
     it 'redirects to rights_and_regs' do
       post :follow_up_submit
       expect(@response).to be_redirect
-      expect(@response.location) to include('/application/rights_and_regs')
+      expect(@response.location).to include('/application/rights_and_regs')
     end
   end
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -267,12 +267,21 @@ RSpec.describe ApplicationController, :type => :controller do
   end
 
   describe 'POST /application/info_sharing' do
-    it 'redirects to rights_and_regs' do
+    it 'redirects to follow_up' do
       post :info_sharing_submit
       expect(@response).to be_redirect
-      expect(@response.location).to include('/application/rights_and_regs')
+      expect(@response.location).to include('/application/follow_up')
     end
+  end
 
+  describe 'GET /application/follow_up' do
+    it 'responds successfully' do
+      get :follow_up
+      expect(@response.status).to eq(200)
+    end
+  end
+
+  describe 'POST /application/follow_up' do
     context 'with all options selected' do
       it 'stores all of the content method preference into session' do
         all_options_selected_params_hash = { :contact_by_phone_call => 'on', :contact_by_text_message => 'on', :contact_by_email => 'on' }
@@ -291,7 +300,14 @@ RSpec.describe ApplicationController, :type => :controller do
         end
       end
     end
+
+    it 'redirects to rights_and_regs' do
+      post :follow_up_submit
+      expect(@response).to be_redirect
+      expect(@response.location) to include('/application/rights_and_regs')
+    end
   end
+
 
   describe 'GET /application/rights_and_regs' do
     it 'responds successfully' do

--- a/spec/features/all_features_spec.rb
+++ b/spec/features/all_features_spec.rb
@@ -92,6 +92,8 @@ feature 'User goes through full application (up to review and submit)' do
       click_on('Next Step')
       expect(page.current_path).to eq('/application/info_sharing')
       click_on("I agree")
+      expect(page.current_path).to eq('/application/follow_up')
+      click_on("Next Step")
       expect(page.current_path).to eq('/application/rights_and_regs')
       click_on("I understand")
       expect(page.current_path).to eq('/application/review_and_submit')

--- a/spec/lib/calfresh_spec.rb
+++ b/spec/lib/calfresh_spec.rb
@@ -175,7 +175,7 @@ describe Calfresh do
 
         it 'sends correct core body input to the Prawn document' do
           expect(fake_prawn_document).to have_received(:text).with(<<EOF
-I, #{test_input[:name]}, authorize you to release the following information regarding my CalFresh application or active case to Code for America:
+I, #{name}, authorize you to release the following information regarding my CalFresh application or active case to Code for America for :
 
 - Case number
 - Current and past application status
@@ -184,17 +184,25 @@ I, #{test_input[:name]}, authorize you to release the following information rega
 - Reasons my case was pended or denied
 - Description of all verification documents that were submitted
 
-Code for America will use this information to make sure my case is processed properly.
+Code for America will use this information to make sure my case is processed properly. This release is valid for one year from the date of application submission.
 EOF
 )
-          expect(fake_prawn_document).to have_received(:text).with(<<EOF
-Name: #{test_input[:name]}
-Date of birth: #{test_input[:date_of_birth]}
+      pdf.image(params[:signature_png_path], scale: 0.3)
+      pdf.text(<<EOF
+Name: #{name}
+Date of birth: #{params[:client_information][:date_of_birth]}
 
 Code for America
 155 9th Street, San Francisco 94103
 (415) 625-9633
 www.codeforamerica.org
+EOF
+)
+
+Leo O'Farrell
+CalFresh Program Director
+leo.o'farrell@sfgov.org
+
 EOF
 )
         end

--- a/spec/lib/calfresh_spec.rb
+++ b/spec/lib/calfresh_spec.rb
@@ -175,7 +175,7 @@ describe Calfresh do
 
         it 'sends correct core body input to the Prawn document' do
           expect(fake_prawn_document).to have_received(:text).with(<<EOF
-I, #{name}, authorize you to release the following information regarding my CalFresh application or active case to Code for America for :
+I, #{test_input[:name]}, authorize you to release the following information regarding my CalFresh application or active case to Code for America for :
 
 - Case number
 - Current and past application status
@@ -187,22 +187,14 @@ I, #{name}, authorize you to release the following information regarding my CalF
 Code for America will use this information to make sure my case is processed properly. This release is valid for one year from the date of application submission.
 EOF
 )
-      pdf.image(params[:signature_png_path], scale: 0.3)
-      pdf.text(<<EOF
-Name: #{name}
-Date of birth: #{params[:client_information][:date_of_birth]}
+      expect(fake_prawn_document).to have_received(:text).with(<<EOF
+Name: #{test_input[:name]}
+Date of birth: #{test_input[:date_of_birth]}
 
 Code for America
 155 9th Street, San Francisco 94103
 (415) 625-9633
 www.codeforamerica.org
-EOF
-)
-
-Leo O'Farrell
-CalFresh Program Director
-leo.o'farrell@sfgov.org
-
 EOF
 )
         end


### PR DESCRIPTION
Closes #386 (except for issues mentioned there that are more fully represented in #406). We will likely want to continue to iterate on language, but this PR is more structural than copywriting.

The crux of this PR is a new view `/follow_up.erb`. This view solicits the applicant to choose which channels they prefer for us to follow up with them about case status through. This was formerly found on `/info_sharing`, but during copy improvements, it became clear that we should separate the concerns—a request for someone's permission to release personal information is a relatively high cognitive load, and almost ethically deserves to be presented without distraction. 

- Copy improvements to `/info_sharing`.
- Simplification of '/info_sharing` via the removal of the question and options of follow up channel.
- Authoring of `/follow_up` to contain that question and user input.
- Associated routes and controller code.
- Associated feature and integration tests.
- Specification in the Release of Information PDF that the release is valid for one year.

You can see the difference in these screenshots. This has been tested on dev, and the email output has been checked.

One question this work raised for me is how we are actually handling the "preferred channel" input from the user. I assume it is simply saved in the database, and nothing else is done with it currently.

#### Before
`/info_sharing`
![image](https://cloud.githubusercontent.com/assets/2983464/6583351/de51b1aa-c720-11e4-9afc-31a1cd10bc50.png)

#### After 
`/info_sharing`
![image](https://cloud.githubusercontent.com/assets/2983464/6583363/f4338962-c720-11e4-9888-1624423c3961.png)
`/follow_up`
![image](https://cloud.githubusercontent.com/assets/2983464/6583374/00a95276-c721-11e4-826f-f018bb27c802.png)