### PR TITLE
update help contact info

### DIFF
--- a/app/views/application/complete.erb
+++ b/app/views/application/complete.erb
@@ -13,7 +13,7 @@
         <li class="list-item">If you disagree with the decision for your application, you can file a State hearing by calling (800) 952-5253.</li>
         <li class="list-item">If you have been treated unfairly you can call the California Civil Rights Bureau at (866) 741-6241 and tell them what happened.</li>
     </ul>
-    <p class="page-context">Please email <a href="mailto:health-lab@codeforamerica.org?subject=Clean Feedback">health-lab@codeforamerica.org</a> if you have any questions or feedback about this online application tool. However&mdash;we don't work for the County of San Francisco, so we won't be able to answer any questions about your case.</p>
+    <p class="page-context">Please email <a href="mailto:help@cleanassist.org?subject=Clean Feedback">help@cleanassist.org</a> if you have any questions or feedback about this online application tool. However&mdash;we don't work for the County of San Francisco, so we won't be able to answer any questions about your case.</p>
 	<div class="page-footer">
 		<a href="/" class="btn btn-primary form-button-link-solo">Start a new application</a>
 	</div>

--- a/app/views/application/document_instructions.erb
+++ b/app/views/application/document_instructions.erb
@@ -30,7 +30,7 @@
 				<p class="page-context"><b>In the next few days</b>, expect a phone call from HSA. Together, you'll walk through the application you submitted, and the documents you've sent in via email. During this conversation, staff will tell you whether or not you've qualified.</p>
 			</li>
 		</ol>
-		<p class="homepage-subheader">Have questions? Don't hesitate to call Jake Solomon and the Clean Assist team at <strong>(510) 206-8727.</strong></p>
+		<p class="homepage-subheader">Have questions? Don't hesitate to call Jake Solomon and the Clean Assist team at <strong>(415) 319-6501.</strong></p>
 		<br>
 	</div>
 </form>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,8 +39,8 @@
   <div class="footer">
     <div class="col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
       <p class="footer-content"><b>Need Help? Get in touch.</b></p>
-      <p class="footer-content">Call (510) 206-8727</p>
-      <p class="footer-content">Email <a href="mailto:health-lab@codeforamerica.org">health-lab@codeforamerica.org</a></p>
+      <p class="footer-content">Call or text (415) 319-6501</p>
+      <p class="footer-content">Email <a href="mailto:help@cleanassist.org">help@cleanassist.org</a></p>
   </div>
 </body>
 </html>

--- a/public/404.html
+++ b/public/404.html
@@ -109,7 +109,7 @@
             <p>Email the documents to <a href="mailto:food@sfgov.org?subject=Pending Intake&body=Hi! Attached is one or more verification documents for a client who submitted an application (CF285) for CalFresh today.">food@sfgov.org</a>. In the subject line, write "Pending Intake for [Applicant Name]". In the body of the email, describe the attached documents, and state that the application was submitted on today's date and time.</p>
           </li>
         </ul>
-        <p>Need help right away? Call us at <b>415-691-2512</b> or send a note to <a href="mailto:health-lab@codeforamerica.org">health-lab@codeforamerica.org</a>.</p>
+        <p>Need help right away? Call us at <b>(415) 319-6501</b> or send a note to <a href="mailto:help@cleanassist.org">help@cleanassist.org</a>.</p>
       </div>
     </div>
   </div>

--- a/public/500.html
+++ b/public/500.html
@@ -109,7 +109,7 @@
             <p>Email the documents to <a href="mailto:food@sfgov.org?subject=Pending Intake&body=Hi! Attached is one or more verification documents for a client who submitted an application (CF285) for CalFresh today.">food@sfgov.org</a>. In the subject line, write "Pending Intake for [Applicant Name]". In the body of the email, describe the attached documents, and state that the application was submitted on today's date and time.</p>
           </li>
         </ul>
-        <p>Need help right away? Call us at <b>415-691-2512</b> or send a note to <a href="mailto:health-lab@codeforamerica.org">health-lab@codeforamerica.org</a>.</p>
+        <p>Need help right away? Call us at <b>(415) 319-6501</b> or send a note to <a href="mailto:help@cleanassist.org">help@cleanassist.org</a>.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
- Change health-lab@ to help@cleanassist.org throughout
- Change (510) 206-8727 to (415) 319-6501 throughout (calls forward to me, messages go to Front)
- Closes #518 