### PR TITLE
Doc upload redux confirmation page

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -191,6 +191,7 @@ body {
 	line-height: 1.4em;
 	font-weight: 700;
 	margin-bottom: 0;
+	text-align: center;
 }
 
 
@@ -626,6 +627,40 @@ input.disabled {
 /* Smartphones (portrait) ----------- */
 @media only screen and (max-width : 320px) {
 /* Styles */
+}
+
+@media print {
+	.page-header {
+		font-size: 32px;
+	}
+	.page-context {
+		font-size: 14px;
+	}
+	.homepage-subheader {
+		text-align: left;
+		font-size: 24px;
+	}
+	.step-title {
+		font-size: 18px;
+	}
+	.step-explanation {
+		font-size: 14px;
+	}
+	.masthead {
+		display: none;
+	}
+	.circle {
+		display: none;
+	}
+	.step-title {
+		padding-top: 1em;
+	}
+	.page-footer {
+		display: none;
+	}
+	.footer {
+		display: none;
+	}
 }
 
  /* B O O T S R A P   H A C K S */

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -218,7 +218,7 @@ EOF
       )
       @email_result_application = client.send(mail)
       puts @email_result_application
-    redirect_to '/application/document_instructions'
+    redirect_to '/application/confirmation'
   end
 
   def document_instructions

--- a/app/views/application/confirmation.erb
+++ b/app/views/application/confirmation.erb
@@ -1,31 +1,31 @@
 <form name="confirmation" action="/application/confirmation" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
 	<h2 class="page-header">You're application has been submitted!</h2>
-	<p class="page-context">There are two more steps before it can be approved&mdash;sending verification documents in, and having your interview with Human Services Agency staff.</p>
-	<p class="page-context"><b>Already have documents on hand?</b></p>
-	<p class="page-context">If you have already gathered documents about your income, expenses and identification, please upload photos of them now.<p>
-	<div class="row form-group">
-		<div class="col-lg-6 form-button-col">
-			<p class="form-context">Yes, I have documents ready to send. Let's get started!</p>
-			<br>
-			<a href="/documents/<%= @user_token %>/0" class="btn form-button" autofocus="autofocus">Start uploading</a>
-		</div>
-		<div class="col-lg-6 form-button-col">
-			<p class="form-context">No, I'll need to gather my documents and submit another time.</p>
-			<br>
-			<a href="/complete" class="btn form-button">Call it a day</a>
-		</div>
-	</div>
-	<br>
-	<div class="form-group">
-		<p class="form-label">Not sure what kind of documents you need?</p>
-		<p class="page-context">Documents you'll need include those show your income, living expenses, and personal identification. Valid documents include:
-		<ul class="list">
-			<li class="list-item">Driver's licenses and passports</li>
-			<li class="list-item">Bank statements</li>
-			<li class="list-item">Lease agreements</li>
-			<li class="list-item">Utility bills</li>
-			<li class="list-item">Written and signed statements</li>
-		</ul>
-		<p class="page-context">You'll need to provide government ID for each person you cook and prepare food with, as well.</p>
+	<p class="page-context">There are a a few more steps before you can receive and use your benefits. Stay in touch with your assister&mdash;they can help you through the rest of the process.</p>
+	<p class="homepage-subheader" style="text-align:center">Here's whats next</p>
+	  <div class="row steps-to-enroll" style="margin-top: 0; padding-top: 0;">
+	    <div class="col-md-4">
+	      <div class="step-to-enroll">
+	        <div class="circle step-to-enroll-icon">1</div>
+	        <h4 class="step-title">Phone Call with HSA Staff</h4>
+	        <p class="step-explanation">Expect a phone call from San Francisco HSA. During the call, you will review your application.</p>
+	      </div>
+	    </div>
+	    <div class="col-md-4">
+	      <div class="step-to-enroll">
+	        <div class="circle step-to-enroll-icon">2</div>
+	        <h4 class="step-title">Submit any Other Documents</h4>
+	        <p class="step-explanation">You may need to submit other documents regarding residency, income and expenses</p>
+	      </div>
+	    </div>
+	    <div class="col-md-4">
+	      <div class="step-to-enroll">
+	        <div class="circle step-to-enroll-icon">3</div>
+	        <h4 class="step-title">Get Approved and Receive Benefits</h4>
+	        <p class="step-explanation">After providing the necessary information, you'll receive monthly benefits to help pay for food and groceries.</p>
+	      </div>
+	    </div>
+	  </div>
+	<div class="page-footer">
+		<a href="/" class="btn btn-primary form-button-link-solo">Start a new application</a>
 	</div>
 </form>

--- a/app/views/application/documents.erb
+++ b/app/views/application/documents.erb
@@ -9,8 +9,6 @@
           <!-- The fileinput-button span is used to style the file input field as button -->
           <span class="btn fileinput-button form-button">
             <i class="icon-plus icon-white"></i>
-            <!-- testing -->
-            <!--<span class="glyphicon glyphicon-picture"></span>-->
             <span> Add files...</span>
             <input type="hidden" name="upload[document_set_key]" value="<%= @document_set_key %>" />
               <%= f.file_field :upload %>

--- a/app/views/application/index.erb
+++ b/app/views/application/index.erb
@@ -23,7 +23,7 @@
       <div class="step-to-enroll">
         <div class="circle step-to-enroll-icon">3</div>
         <h4 class="step-title">Receive benefits</h4>
-        <p class="step-explanation">At providing the necessary information, you'll receive monthly benefits to help pay for food and groceries.</p>
+        <p class="step-explanation">After providing the necessary information, you'll receive monthly benefits to help pay for food and groceries.</p>
       </div>
     </div>
   </div>

--- a/app/views/application/interview.erb
+++ b/app/views/application/interview.erb
@@ -2,10 +2,15 @@
   <h3 class="page-header">When should the HSA call you to review your application?</h3>
   <p class="page-context">Before you are approved for CalFresh, you'll need to speak with HSA staff. During the interview, they will review your application and ask for details about your income and expenses. The call usually takes about 15 minutes. Staff will do their best to contact you at the phone number you provided, during the days and times you choose below.</p>
   <div class="form-group">
+    <label class="page-context">
+      <input type="checkbox" name="select-all" id="select-all" autofocus="autofocus"> Any time is fine
+    </label>
+  </div>
+  <div class="form-group">
     <div class="times-of-day middle">
       <div class="checkbox time-of-day">
         <label class="page-context">
-          <input type="checkbox" name="early-morning" autofocus="autofocus"> Early morning
+          <input type="checkbox" name="early-morning"> Early morning
         </label>
       </div>
       <div class="checkbox time-of-day">
@@ -57,3 +62,18 @@
     </div>
   </div>
 </form>
+<script>
+$('#select-all').click(function(event) {
+    if(this.checked) {
+        // Iterate each checkbox
+        $(':checkbox').each(function() {
+            this.checked = true;
+        });
+    }
+  else {
+    $(':checkbox').each(function() {
+          this.checked = false;
+      });
+  }
+});
+</script>

--- a/spec/features/all_features_spec.rb
+++ b/spec/features/all_features_spec.rb
@@ -84,6 +84,8 @@ feature 'User goes through full application (up to review and submit)' do
       click_on('Next Step')
       expect(page.current_path).to eq('/application/additional_household_question')
       click_link('No')
+      expect(page.current_path).to eq('/application/documents')
+      click_link("Next Step")
       expect(page.current_path).to eq('/application/interview')
       check('monday')
       check('friday')


### PR DESCRIPTION
Doesn't close, but begins to address #355. Should close #490.

- After app submission, user is taken to `/confirmation` instead of `/document_instructions`. 
- Routes and feature tests updated accordingly
- New markup and copy for `/confirmation'. This is largely a placeholder until we get feedback from the FBers on the sketch that will finalize #355.
- Basic print styles for `/confirmation`, again, a placeholder until we fully address #355.
