### PR TITLE
Redefine click on the upload file input, fixing RT/IE bug

### DIFF
--- a/app/views/application/documents.erb
+++ b/app/views/application/documents.erb
@@ -40,9 +40,19 @@
     </div>
   <% end %>
 
-<script>
 
-$("#file-list").on("click", "#badfile", function() {
+<script>
+//  Fix for IE/RT. Found: https://github.com/tors/jquery-fileupload-rails/issues/33
+  if (navigator.userAgent.indexOf("MSIE 10") > 0) {
+    $("#upload_upload").bind('mousedown',function(event) {
+      $(this).trigger('click')
+    });
+  }
+</script>
+
+
+<script>
+  $("#file-list").on("click", "#badfile", function() {
     console.log("click event")
     $(this).remove();
   });


### PR DESCRIPTION
Closes #513 
-  snippet redefining click events on the input element in question included in `/documents.erb`