### PR TITLE
Copy Updates: Info Sharing and sundry other tailoring

### DIFF
--- a/app/views/application/basic_info.erb
+++ b/app/views/application/basic_info.erb
@@ -1,4 +1,4 @@
-<form name="basic_info" action="/application/basic_info" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1 m-page scene_element scene_element--fadeinup" data-parsley-validate>
+<form name="basic_info" action="/application/basic_info" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1 " data-parsley-validate>
   <h2 class="page-header">Basic information</h2>
 	<div class="form-group">
     <label for="name" class="form-label">Your full name</label>

--- a/app/views/application/documents.erb
+++ b/app/views/application/documents.erb
@@ -3,7 +3,7 @@
     <h2 class="page-header">Upload verification documents</h2>
     <!-- The fileupload-buttonbar contains buttons to add/delete files and start/cancel the upload -->
     <div class="form-group">
-      <p class="page-context">Share documents that show your residency, income, expenses. Upload as many as you like. If you don't have any documents on hand, don't worry&mdash;you can submit them later. </p>
+      <p class="page-context">To receive CalFresh, you'll need to share documents that show your residency, income, expenses. You can upload as many as you like right now. If you don't have any documents on hand, don't worry&mdash;you can always share them with HSA later. </p>
       <div class="row">
         <div class="span7 col-md-4 col-sm-12">
           <!-- The fileinput-button span is used to style the file input field as button -->

--- a/app/views/application/household_question.erb
+++ b/app/views/application/household_question.erb
@@ -1,7 +1,7 @@
 <form name="household_question" action="/application/household_question" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
   <h2 class="page-header">Do you live with others?</h2>
-  <p class="page-context">CalFresh supports both individuals and families. The amount of benefits you'll receive is influenced by the number of people the benefits need to support. You'll need to provide personal information about each person you share food and cooking expenses with.</p>
-  <p class="page-context"><b>Only</b> include adult family members, children, and roommates that you buy groceries and eat with daily. Don't include roommates that live on their own budget.</p>
+  <p class="page-context">CalFresh supports both individuals and families. The amount of benefits you'll receive is influenced by the number of people the benefits need to support. As a result, you'll need to provide personal information about each person you share food and cooking expenses with.</p>
+  <p class="page-context"><b>Only include </b> adult family members, children, and roommates that you buy groceries and eat with daily. Don't include roommates that live on their own budget.</p>
   <br>
   <div class="row form-group">
     <div class="col-xs-6 form-button-col">

--- a/app/views/application/info_sharing.erb
+++ b/app/views/application/info_sharing.erb
@@ -1,7 +1,7 @@
 <form id="info_sharing" name="info_sharing" action="/application/info_sharing" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1" data-parsley-validate>
   <h2 class="page-header">Sharing your case information</h2>
-  <p class="page-context">When you apply for CalFresh with this website, we ask that you agree to release the information you've documented today to the CleanAssist.org team at Code for America. We will <i>only</i> use this information to check on whether your case is processed properly by the San Francisco Human Services Agency.</p>
-  <p class="page-context">Specifically, we ask you to agree to release the following information to help us follow up on your behalf:
+  <p class="page-context">When you apply for CalFresh with this website, we ask that you agree to share your case information with the CleanAssist.org team. We will <i>only</i> use this information to ensure your case is processed properly by the San Francisco Human Services Agency.</p>
+  <p class="page-context">Specifically, we ask you to agree to release the following information:
     <ul class="list">
       <li class="list-item">Case number</li>
       <li class="list-item">Current and past application status</li>
@@ -11,8 +11,7 @@
     </ul>
   </p>
   <div class="form-group">
-    <p class="form-label">How should we follow up with you about your case status?</p>
-    <p class="form-context">To ensure your application is processed properly, we may need to get in touch.</p>
+    <p class="form-label">If we need to contact you about your case, how should we get in touch?</p>
     <div class="times-of-day middle">
       <div class="checkbox time-of-day">
         <label class="page-context">

--- a/app/views/application/info_sharing.erb
+++ b/app/views/application/info_sharing.erb
@@ -1,25 +1,22 @@
 <form id="info_sharing" name="info_sharing" action="/application/info_sharing" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1" data-parsley-validate>
-  <h2 class="page-header">Caring for your case</h2>
-  <p class="page-context"><b>CleanAssist isn't just a way to apply online&mdash;it's also a way to ensure your application is processed correctly. Staff at Code for America will check in on your application, and let you know if there are any issues.</b></p>
+  <h2 class="page-header">Sharing your case information</h2>
+  <p class="page-context">When you apply for CalFresh with this website, we ask that you agree to release the information you've documented today to the CleanAssist.org team at Code for America. We will <i>only</i> use this information to check on whether your case is processed properly by the San Francisco Human Services Agency.</p>
+  <p class="page-context">Specifically, we ask you to agree to release the following information to help us follow up on your behalf:
+    <ul class="list">
+      <li class="list-item">Case number</li>
+      <li class="list-item">Current and past application status</li>
+      <li class="list-item">Dates and reasons for all changes to application status</li>
+      <li class="list-item">Reasons for cases judgements</li>
+      <li class="list-item">Description of all verification documents</li>
+    </ul>
+  </p>
   <div class="form-group">
-    <p class="page-context">To do that, we ask that you agree to release the information you've documented today to Code for America. We will <i>only</i> use your application information to to make sure your case is processed properly.</p>
-    <p class="page-context">Specifically, we ask you to agree to release the following information to help us advocate on your behalf:
-      <ul class="list">
-        <li class="list-item">Case number</li>
-        <li class="list-item">Current and past application status</li>
-        <li class="list-item">Dates and reasons for all changes to application status</li>
-        <li class="list-item">Reasons for cases judgements</li>
-        <li class="list-item">Description of all verification documents</li>
-      </ul>
-    </p>
-  </div>
-  <div class="form-group">
-    <p class="form-label">How should we contact you if needed?</p>
-    <p class="form-context">In our work to ensure your application is processed properly, we may need to get in touch. How would you prefer we contact you about your case status?</p>
+    <p class="form-label">How should we follow up with you about your case status?</p>
+    <p class="form-context">To ensure your application is processed properly, we may need to get in touch.</p>
     <div class="times-of-day middle">
       <div class="checkbox time-of-day">
         <label class="page-context">
-          <input type="checkbox" name="contact_by_phone_call" autofocus="autofocus"> Phone Call
+          <input type="checkbox" name="contact_by_phone_call"> Phone Call
         </label>
       </div>
       <div class="checkbox time-of-day">

--- a/app/views/application/info_sharing.erb
+++ b/app/views/application/info_sharing.erb
@@ -1,5 +1,5 @@
 <form id="info_sharing" name="info_sharing" action="/application/info_sharing" method="post" class="form col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1" data-parsley-validate>
-  <h2 class="page-header">Sharing your case information</h2>
+  <h2 class="page-header">Share your case information</h2>
   <p class="page-context">When you apply for CalFresh with this website, we ask that you agree to share your case information with the CleanAssist.org team. We will <i>only</i> use this information to ensure your case is processed properly by the San Francisco Human Services Agency.</p>
   <p class="page-context">Specifically, we ask you to agree to release the following information:
     <ul class="list">

--- a/app/views/application/review_and_submit.erb
+++ b/app/views/application/review_and_submit.erb
@@ -9,10 +9,8 @@
       <input type="checkbox" name="signature_agree" id="signature_agree" required required data-parsley-required-message="Please check this box to agree and submit this application"> I agree that I have been honest on this application and that I intend to apply for CalFresh
     </label>
   </div>
-
-  <p class="form-context">After you submit, you'll have the chance to provide documents regarding you identification, income, expenses and other relevant information.</p>
   <div class="page-footer">
-      <button id="submit_button" class="btn next-step" type="submit" value="Submit Application" data-loading-text="Sending in your application...">Submit Application</button>
+      <button id="submit_button" class="btn next-step" type="submit" value="Submit Application" data-loading-text="Sending...">Submit Application</button>
   </div>
 </form>
 <script>


### PR DESCRIPTION
- This updates the copy to be more approachable on /info_sharing, and also more accurate regarding how we use the information now that we are not doing active case follow up.
- It does not quite deprecate the PR #421 from so many moons ago, because that work included breaking things into two separate views for follow up and info sharing.
- I also just took a pass through the entire app and cleaned up some language here and there, including removing copy to close #526 